### PR TITLE
fix(setup): fixed setup links reffering to old pages that no longer exist on website

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,20 +144,11 @@ const keypress = async (skip: boolean): Promise<void> => {
   })
 }
 
-const getStepsUrl = () => {
-  const p = platform()
-
-  if (p === 'win32') {
-    return 'windows'
-  }
-  if (p === 'darwin') {
-    return 'macros'
-  }
-  return 'linux'
-}
-
 const runInit = async (argv: Argv): Promise<void> => {
-  const setupLink = `https://tauri.studio/docs/getting-started/setting-up-${getStepsUrl()}/`
+  const p = platform()
+  const setupPlatform =
+    p === 'win32' ? 'windows' : p === 'darwin' ? 'macos' : 'linux'
+  const setupLink = `https://tauri.studio/docs/getting-started/setting-up-${setupPlatform}/`
 
   // prettier-ignore
   console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,13 +144,20 @@ const keypress = async (skip: boolean): Promise<void> => {
   })
 }
 
+const getStepsUrl = () => {
+  const p = platform()
+
+  if (p === 'win32') {
+    return 'windows'
+  }
+  if (p === 'darwin') {
+    return 'macros'
+  }
+  return 'linux'
+}
+
 const runInit = async (argv: Argv): Promise<void> => {
-  const setupLink =
-    platform() === 'win32'
-      ? 'https://tauri.studio/en/docs/get-started/setup-windows/'
-      : platform() === 'darwin'
-      ? 'https://tauri.studio/en/docs/get-started/setup-macos/'
-      : 'https://tauri.studio/en/docs/get-started/setup-linux/'
+  const setupLink = `https://tauri.studio/docs/getting-started/setting-up-${getStepsUrl()}/`
 
   // prettier-ignore
   console.log(


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This fixes an issue with the current `create-tauri-app` command where the links to get setup will refer to a page on the website that no longer exists.

This page is `https://tauri.studio/docs/get-started/setup-linux/` and has since been replaced by `https://tauri.studio/docs/getting-started/setting-up-linux/`, but the cli has not been updated, and this is what is introduced in this PR.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
