### PR TITLE
fix: Use vite's new default port 5173 in devPath

### DIFF
--- a/.changes/default-vite-port.md
+++ b/.changes/default-vite-port.md
@@ -1,0 +1,6 @@
+
+---
+"create-tauri-app": patch
+---
+
+Update the vite recipe to use port 5173, the new default in vite@v3.

--- a/src/recipes/vite.ts
+++ b/src/recipes/vite.ts
@@ -15,7 +15,7 @@ const vite: Recipe = {
   configUpdate: ({ cfg, packageManager }) => ({
     ...cfg,
     distDir: `../dist`,
-    devPath: 'http://localhost:3000',
+    devPath: 'http://localhost:5173',
     beforeDevCommand: `${
       packageManager.name === 'npm' ? 'npm run' : packageManager.name
     } dev`,


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary