### PR TITLE
Fix: Use absolute link for splash image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src=".github/splash.png" alt="Rapidly scaffold out a new tauri app project." />
+<img src="https://github.com/tauri-apps/create-tauri-app/raw/dev/.github/splash.png" alt="Rapidly scaffold out a new Tauri app project." />
 
 [![](https://img.shields.io/crates/v/create-tauri-app)](https://crates.io/crates/create-tauri-app)
 [![](https://img.shields.io/npm/v/create-tauri-app.svg)](https://www.npmjs.com/package/create-tauri-app)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-<img src="../../.github/splash.png" alt="Rapidly scaffold out a new tauri app project." />
+<img src="https://github.com/tauri-apps/create-tauri-app/raw/dev/.github/splash.png" alt="Rapidly scaffold out a new Tauri app project." />
 
 [![](https://img.shields.io/crates/v/create-tauri-app)](https://crates.io/crates/create-tauri-app)
 [![](https://img.shields.io/npm/v/create-tauri-app.svg)](https://www.npmjs.com/package/create-tauri-app)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Fixes the splash image for the NPM registry (see broken image below)
<img width="798" alt="Screenshot 2022-08-22 at 17 08 01" src="https://user-images.githubusercontent.com/15347255/185967623-aef28578-5311-4003-a1fa-50d9ca061e79.png">

