### PR TITLE
refactor: replace deprecated code

### DIFF
--- a/.changes/yew-deprecated.md
+++ b/.changes/yew-deprecated.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+Replace deprecated functions in `yew` template.

--- a/packages/cli/fragments/fragment-yew/_Cargo.toml
+++ b/packages/cli/fragments/fragment-yew/_Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+serde-wasm-bindgen = "0.4.3"
 js-sys = "0.3.59"
 serde = { version = "1.0.140", features = ["derive"] }
 wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }

--- a/packages/cli/fragments/fragment-yew/src/app.rs
+++ b/packages/cli/fragments/fragment-yew/src/app.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -38,7 +39,7 @@ pub fn app() -> Html {
                     // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
                     let new_msg = invoke(
                         "greet",
-                        JsValue::from_serde(&GreetArgs { name: &*name }).unwrap(),
+                        to_value(&GreetArgs { name: &*name }).unwrap(),
                     )
                     .await;
                     log(&new_msg.as_string().unwrap());


### PR DESCRIPTION
Signed-off-by: xTeKc <bcd3v@pm.me>

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
This PR replaces the deprecated JsValue::from_serde with serde_wasm_bindgen::to_value, which essentially does the same thing and converts the Rust value into a JsValue. All tests pass and everything works as expected after the refactor.