### PR TITLE
expose internal modules

### DIFF
--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -9,8 +9,8 @@ use crate::{colors::*, package_manager::PackageManager};
 
 mod cli;
 mod colors;
-mod package_manager;
-mod template;
+pub mod package_manager;
+pub mod template;
 
 pub fn run<I, A>(args: I, bin_name: Option<String>)
 where

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -9,8 +9,24 @@ use crate::{colors::*, package_manager::PackageManager};
 
 mod cli;
 mod colors;
-pub mod package_manager;
-pub mod template;
+mod package_manager;
+mod template;
+
+pub mod internal {
+    //! Re-export of create-tauri-app internals
+    //!
+    //! ## Warning
+    //!
+    //! This is meant to be used internally only so use at your own risk
+    //! and expect APIs to break without a prior notice.
+    pub mod package_manager {
+        pub use crate::package_manager::*;
+    }
+
+    pub mod template {
+        pub use crate::template::*;
+    }
+}
 
 pub fn run<I, A>(args: I, bin_name: Option<String>)
 where


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

This change exposes the internal `package_manager` and `template` modules. I am working on a project scaffolding tool for [rspc](https://github.com/oscartbeaumont/rspc) and [Prisma Client Rust](https://github.com/brendonovich/prisma-client-rust) ontop of Tauri or Axum. Having these internals exposed means I can use your templates and just patch on my own changes ontop reducing the maintenance burdon for me and providing a better user experience.

It would be nice if the internals were public so I don't need to maintain a fork of this repository and so I can publish my CLI to crates.io (which isn't possible if I have a Git dependency).

I understand there would be no guarantees in the stability of these API's between versions. If that's a problem I could change it to expose the modules as `create_tauri_app::internal::*` and put a documentation warning about there stability.

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary