### PR TITLE
Fix: disable SSR by default in SvelteKit templates (fix for "feat: Sveltekit templates #200")

### DIFF
--- a/.changes/svelte-kit-ssr.md
+++ b/.changes/svelte-kit-ssr.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Disable SSR by default in `svelte-kit` and `svelte-kit-ts` templates.

--- a/packages/cli/fragments/fragment-svelte-kit-ts/src/routes/+layout.ts
+++ b/packages/cli/fragments/fragment-svelte-kit-ts/src/routes/+layout.ts
@@ -1,2 +1,3 @@
+export const ssr = false;
 export const prerender = true;
 export const csr = true;

--- a/packages/cli/fragments/fragment-svelte-kit/src/routes/+layout.js
+++ b/packages/cli/fragments/fragment-svelte-kit/src/routes/+layout.js
@@ -1,2 +1,3 @@
+export const ssr = false;
 export const prerender = true;
 export const csr = true;


### PR DESCRIPTION
Turns off SvelteKit's SSR by default, which is unnecessary and prevents usage of `@tauri-apps/api/window`.

Issue & solution: https://github.com/sveltejs/kit/tree/master/packages/adapter-static#turn-off-ssr
Discussion: https://github.com/tauri-apps/create-tauri-app/pull/200#issuecomment-1325911698



### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
