### PR TITLE
feat(cli/templates): add `solid-start` and `solid-start-ts` templates

### DIFF
--- a/.changes/solid-start-templates.md
+++ b/.changes/solid-start-templates.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": minor
+"create-tauri-app-js": minor
+---
+
+Add `solid-start` and `solid-start-ts` template.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Currently supported template presets include:
 - `clojurescript`
 - `svelte-kit`
 - `svelte-kit-ts`
+- `solid-start`
+- `solid-start-ts`
 
 You can use `.` for the project name to scaffold in the current directory.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,6 +45,10 @@ Currently supported template presets include:
 - `preact-ts`
 - `angular`
 - `clojurescript`
+- `svelte-kit`
+- `svelte-kit-ts`
+- `solid-start`
+- `solid-start-ts`
 
 You can use `.` for the project name to scaffold in the current directory.
 

--- a/packages/cli/fragments/fragment-solid-start-ts/.vscode/extensions.json
+++ b/packages/cli/fragments/fragment-solid-start-ts/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["tauri-apps.tauri-vscode", "rust-lang.rust-analyzer"]
+}

--- a/packages/cli/fragments/fragment-solid-start-ts/README.md
+++ b/packages/cli/fragments/fragment-solid-start-ts/README.md
@@ -1,0 +1,7 @@
+# Tauri + Solid-Start + Typescript
+
+This template should help get you started developing with Tauri, Solid-Start and Typescript in Vite.
+
+## Recommended IDE Setup
+
+- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)

--- a/packages/cli/fragments/fragment-solid-start-ts/_cta_manifest_
+++ b/packages/cli/fragments/fragment-solid-start-ts/_cta_manifest_
@@ -1,0 +1,14 @@
+# Copyright 2019-2022 Tauri Programme within The Commons Conservancy
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+beforeDevCommand = {{pkg_manager_run_command}} dev
+beforeBuildCommand = {{pkg_manager_run_command}} build
+devPath = http://localhost:3000
+distDir = ../dist/public
+
+[files]
+vite.svg = public/vite.svg
+tauri.svg = public/tauri.svg
+solid.svg = public/solid.svg
+style.css = src/root.css

--- a/packages/cli/fragments/fragment-solid-start-ts/_gitignore
+++ b/packages/cli/fragments/fragment-solid-start-ts/_gitignore
@@ -1,0 +1,31 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+/build
+/.solid
+/package
+.env
+.env.*
+!.env.example

--- a/packages/cli/fragments/fragment-solid-start-ts/package.json
+++ b/packages/cli/fragments/fragment-solid-start-ts/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "{{package_name}}",
+  "version": "0.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "solid-start dev",
+    "build": "solid-start build",
+    "start": "solid-start start",
+    "tauri": "tauri"
+  },
+  "type": "module",
+  "license": "MIT",
+  "devDependencies": {
+    "solid-start-static": "^0.2.9",
+    "typescript": "^4.9.4",
+    "vite": "^4.0.3",
+    "@tauri-apps/cli": "^1.2.2"
+  },
+  "dependencies": {
+    "@solidjs/meta": "^0.28.2",
+    "@solidjs/router": "^0.6.0",
+    "solid-js": "^1.6.6",
+    "solid-start": "^0.2.9",
+    "undici": "^5.14.0",
+    "@tauri-apps/api": "^1.2.0"
+  },
+  "engines": {
+    "node": ">=16.8"
+  }
+}

--- a/packages/cli/fragments/fragment-solid-start-ts/src/components/Greet.tsx
+++ b/packages/cli/fragments/fragment-solid-start-ts/src/components/Greet.tsx
@@ -1,0 +1,30 @@
+import {createSignal} from "solid-js";
+
+export default function Greet() {
+    const [greetMsg, setGreetMsg] = createSignal("");
+    const [name, setName] = createSignal("");
+
+    async function greet() {
+        const {invoke} = await import("@tauri-apps/api/tauri");
+        // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
+        setGreetMsg(await invoke("greet", {name: name()}));
+    }
+
+
+    return (
+        <>
+            <div class="row">
+                <div>
+                    <input
+                        id="greet-input"
+                        onChange={(e) => setName(e.currentTarget.value)}
+                        placeholder="Enter a name..."/>
+                    <button type="button" onClick={() => greet()}>
+                        Greet
+                    </button>
+                </div>
+            </div>
+            <p>{greetMsg}</p>
+        </>
+    );
+}

--- a/packages/cli/fragments/fragment-solid-start-ts/src/entry-client.tsx
+++ b/packages/cli/fragments/fragment-solid-start-ts/src/entry-client.tsx
@@ -1,0 +1,3 @@
+import { mount, StartClient } from "solid-start/entry-client";
+
+mount(() => <StartClient />, document);

--- a/packages/cli/fragments/fragment-solid-start-ts/src/entry-server.tsx
+++ b/packages/cli/fragments/fragment-solid-start-ts/src/entry-server.tsx
@@ -1,0 +1,9 @@
+import {
+  createHandler,
+  renderAsync,
+  StartServer,
+} from "solid-start/entry-server";
+
+export default createHandler(
+  renderAsync((event) => <StartServer event={event} />)
+);

--- a/packages/cli/fragments/fragment-solid-start-ts/src/root.tsx
+++ b/packages/cli/fragments/fragment-solid-start-ts/src/root.tsx
@@ -1,0 +1,39 @@
+// @refresh reload
+import { Suspense } from "solid-js";
+import {
+  A,
+  Body,
+  ErrorBoundary,
+  FileRoutes,
+  Head,
+  Html,
+  Meta,
+  Routes,
+  Scripts,
+  Title,
+} from "solid-start";
+import "./root.css";
+
+export default function Root() {
+  return (
+    <Html lang="en">
+      <Head>
+        <Title>SolidStart - Tauri</Title>
+        <Meta charset="utf-8" />
+        <Meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+        <Body class="container">
+        <Suspense>
+          <ErrorBoundary>
+            <A href="/">Index</A>
+            <A href="/about">About</A>
+            <Routes>
+              <FileRoutes />
+            </Routes>
+          </ErrorBoundary>
+        </Suspense>
+        <Scripts />
+      </Body>
+    </Html>
+  );
+}

--- a/packages/cli/fragments/fragment-solid-start-ts/src/routes/[...404].tsx
+++ b/packages/cli/fragments/fragment-solid-start-ts/src/routes/[...404].tsx
@@ -1,0 +1,12 @@
+import {Title} from "solid-start";
+import {HttpStatusCode} from "solid-start/server";
+
+export default function NotFound() {
+    return (
+        <main>
+            <Title>Not Found</Title>
+            <HttpStatusCode code={404}/>
+            <h1>Page Not Found</h1>
+        </main>
+    );
+}

--- a/packages/cli/fragments/fragment-solid-start-ts/src/routes/index.tsx
+++ b/packages/cli/fragments/fragment-solid-start-ts/src/routes/index.tsx
@@ -1,0 +1,26 @@
+import {Title} from "solid-start";
+import Greet from "~/components/Greet";
+
+export default function Home() {
+    return (
+        <main>
+            <Title>Welcome to Tauri!</Title>
+            <h1>Welcome to Tauri!</h1>
+
+            <div class="row">
+                <a href="https://vitejs.dev" target="_blank">
+                    <img src="/vite.svg" class="logo vite" alt="Vite logo"/>
+                </a>
+                <a href="https://tauri.app" target="_blank">
+                    <img src="/tauri.svg" class="logo tauri" alt="Tauri logo"/>
+                </a>
+                <a href="https://start.solidjs.com" target="_blank">
+                    <img src="/solid.svg" class="logo solid-start" alt="Solid-Start logo"/>
+                </a>
+            </div>
+
+            <p>Click on the Tauri, Vite, and Solid-Start logos to learn more.</p>
+            <Greet/>
+        </main>
+    );
+}

--- a/packages/cli/fragments/fragment-solid-start-ts/tsconfig.json
+++ b/packages/cli/fragments/fragment-solid-start-ts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["vite/client"],
+    "baseUrl": "./",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/cli/fragments/fragment-solid-start-ts/vite.config.ts
+++ b/packages/cli/fragments/fragment-solid-start-ts/vite.config.ts
@@ -1,0 +1,26 @@
+import solid from "solid-start/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [solid()],
+
+  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+  // prevent vite from obscuring rust errors
+  clearScreen: false,
+  // tauri expects a fixed port, fail if that port is not available
+  server: {
+    port: 3000,
+    strictPort: true,
+  },
+  // to make use of `TAURI_DEBUG` and other env variables
+  // https://tauri.studio/v1/api/config#buildconfig.beforedevcommand
+  envPrefix: ["VITE_", "TAURI_"],
+  build: {
+    // Tauri supports es2021
+    target: ["es2021", "chrome100", "safari13"],
+    // don't minify for debug builds
+    minify: !process.env.TAURI_DEBUG ? "esbuild" : false,
+    // produce sourcemaps for debug builds
+    sourcemap: !!process.env.TAURI_DEBUG,
+  },
+});

--- a/packages/cli/fragments/fragment-solid-start/.vscode/extensions.json
+++ b/packages/cli/fragments/fragment-solid-start/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["tauri-apps.tauri-vscode", "rust-lang.rust-analyzer"]
+}

--- a/packages/cli/fragments/fragment-solid-start/README.md
+++ b/packages/cli/fragments/fragment-solid-start/README.md
@@ -1,0 +1,7 @@
+# Tauri + Solid-Start + Typescript
+
+This template should help get you started developing with Tauri, Solid-Start and Typescript in Vite.
+
+## Recommended IDE Setup
+
+- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)

--- a/packages/cli/fragments/fragment-solid-start/_cta_manifest_
+++ b/packages/cli/fragments/fragment-solid-start/_cta_manifest_
@@ -1,0 +1,14 @@
+# Copyright 2019-2022 Tauri Programme within The Commons Conservancy
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+beforeDevCommand = {{pkg_manager_run_command}} dev
+beforeBuildCommand = {{pkg_manager_run_command}} build
+devPath = http://localhost:3000
+distDir = ../dist/public
+
+[files]
+vite.svg = public/vite.svg
+tauri.svg = public/tauri.svg
+solid.svg = public/solid.svg
+style.css = src/root.css

--- a/packages/cli/fragments/fragment-solid-start/_gitignore
+++ b/packages/cli/fragments/fragment-solid-start/_gitignore
@@ -1,0 +1,31 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+/build
+/.solid
+/package
+.env
+.env.*
+!.env.example

--- a/packages/cli/fragments/fragment-solid-start/jsconfig.json
+++ b/packages/cli/fragments/fragment-solid-start/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "paths": {
+      "~/*": [
+        "./src/*"
+      ]
+    }
+  }
+}

--- a/packages/cli/fragments/fragment-solid-start/package.json
+++ b/packages/cli/fragments/fragment-solid-start/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "{{package_name}}",
+  "version": "0.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "solid-start dev",
+    "build": "solid-start build",
+    "start": "solid-start start",
+    "tauri": "tauri"
+  },
+  "type": "module",
+  "license": "MIT",
+  "devDependencies": {
+    "solid-start-static": "^0.2.9",
+    "vite": "^4.0.3",
+    "@tauri-apps/cli": "^1.2.2"
+  },
+  "dependencies": {
+    "@solidjs/meta": "^0.28.2",
+    "@solidjs/router": "^0.6.0",
+    "solid-js": "^1.6.6",
+    "solid-start": "^0.2.9",
+    "undici": "^5.14.0",
+    "@tauri-apps/api": "^1.2.0"
+  },
+  "engines": {
+    "node": ">=16.8"
+  }
+}

--- a/packages/cli/fragments/fragment-solid-start/src/components/Greet.jsx
+++ b/packages/cli/fragments/fragment-solid-start/src/components/Greet.jsx
@@ -1,0 +1,30 @@
+import {createSignal} from "solid-js";
+
+export default function Greet() {
+    const [greetMsg, setGreetMsg] = createSignal("");
+    const [name, setName] = createSignal("");
+
+    async function greet() {
+        const {invoke} = await import("@tauri-apps/api/tauri");
+        // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
+        setGreetMsg(await invoke("greet", {name: name()}));
+    }
+
+
+    return (
+        <>
+            <div class="row">
+                <div>
+                    <input
+                        id="greet-input"
+                        onChange={(e) => setName(e.currentTarget.value)}
+                        placeholder="Enter a name..."/>
+                    <button type="button" onClick={() => greet()}>
+                        Greet
+                    </button>
+                </div>
+            </div>
+            <p>{greetMsg}</p>
+        </>
+    );
+}

--- a/packages/cli/fragments/fragment-solid-start/src/entry-client.jsx
+++ b/packages/cli/fragments/fragment-solid-start/src/entry-client.jsx
@@ -1,0 +1,3 @@
+import { mount, StartClient } from "solid-start/entry-client";
+
+mount(() => <StartClient />, document);

--- a/packages/cli/fragments/fragment-solid-start/src/entry-server.jsx
+++ b/packages/cli/fragments/fragment-solid-start/src/entry-server.jsx
@@ -1,0 +1,9 @@
+import {
+  createHandler,
+  renderAsync,
+  StartServer,
+} from "solid-start/entry-server";
+
+export default createHandler(
+  renderAsync((event) => <StartServer event={event} />)
+);

--- a/packages/cli/fragments/fragment-solid-start/src/root.jsx
+++ b/packages/cli/fragments/fragment-solid-start/src/root.jsx
@@ -1,0 +1,39 @@
+// @refresh reload
+import { Suspense } from "solid-js";
+import {
+  A,
+  Body,
+  ErrorBoundary,
+  FileRoutes,
+  Head,
+  Html,
+  Meta,
+  Routes,
+  Scripts,
+  Title,
+} from "solid-start";
+import "./root.css";
+
+export default function Root() {
+  return (
+    <Html lang="en">
+      <Head>
+        <Title>SolidStart - Tauri</Title>
+        <Meta charset="utf-8" />
+        <Meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+        <Body class="container">
+        <Suspense>
+          <ErrorBoundary>
+            <A href="/">Index</A>
+            <A href="/about">About</A>
+            <Routes>
+              <FileRoutes />
+            </Routes>
+          </ErrorBoundary>
+        </Suspense>
+        <Scripts />
+      </Body>
+    </Html>
+  );
+}

--- a/packages/cli/fragments/fragment-solid-start/src/routes/[...404].jsx
+++ b/packages/cli/fragments/fragment-solid-start/src/routes/[...404].jsx
@@ -1,0 +1,12 @@
+import {Title} from "solid-start";
+import {HttpStatusCode} from "solid-start/server";
+
+export default function NotFound() {
+    return (
+        <main>
+            <Title>Not Found</Title>
+            <HttpStatusCode code={404}/>
+            <h1>Page Not Found</h1>
+        </main>
+    );
+}

--- a/packages/cli/fragments/fragment-solid-start/src/routes/index.jsx
+++ b/packages/cli/fragments/fragment-solid-start/src/routes/index.jsx
@@ -1,0 +1,26 @@
+import {Title} from "solid-start";
+import Greet from "~/components/Greet";
+
+export default function Home() {
+    return (
+        <main>
+            <Title>Welcome to Tauri!</Title>
+            <h1>Welcome to Tauri!</h1>
+
+            <div class="row">
+                <a href="https://vitejs.dev" target="_blank">
+                    <img src="/vite.svg" class="logo vite" alt="Vite logo"/>
+                </a>
+                <a href="https://tauri.app" target="_blank">
+                    <img src="/tauri.svg" class="logo tauri" alt="Tauri logo"/>
+                </a>
+                <a href="https://start.solidjs.com" target="_blank">
+                    <img src="/solid.svg" class="logo solid-start" alt="Solid-Start logo"/>
+                </a>
+            </div>
+
+            <p>Click on the Tauri, Vite, and Solid-Start logos to learn more.</p>
+            <Greet/>
+        </main>
+    );
+}

--- a/packages/cli/fragments/fragment-solid-start/vite.config.js
+++ b/packages/cli/fragments/fragment-solid-start/vite.config.js
@@ -1,0 +1,26 @@
+import solid from "solid-start/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [solid()],
+
+  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+  // prevent vite from obscuring rust errors
+  clearScreen: false,
+  // tauri expects a fixed port, fail if that port is not available
+  server: {
+    port: 3000,
+    strictPort: true,
+  },
+  // to make use of `TAURI_DEBUG` and other env variables
+  // https://tauri.studio/v1/api/config#buildconfig.beforedevcommand
+  envPrefix: ["VITE_", "TAURI_"],
+  build: {
+    // Tauri supports es2021
+    target: ["es2021", "chrome100", "safari13"],
+    // don't minify for debug builds
+    minify: !process.env.TAURI_DEBUG ? "esbuild" : false,
+    // produce sourcemaps for debug builds
+    sourcemap: !!process.env.TAURI_DEBUG,
+  },
+});

--- a/packages/cli/src/package_manager.rs
+++ b/packages/cli/src/package_manager.rs
@@ -52,6 +52,8 @@ impl PackageManager {
                 Template::ClojureScript,
                 Template::SvelteKit,
                 Template::SvelteKitTs,
+                Template::SolidStart,
+                Template::SolidStartTs,
             ],
         }
     }

--- a/packages/cli/src/template.rs
+++ b/packages/cli/src/template.rs
@@ -35,6 +35,8 @@ pub enum Template {
     ClojureScript,
     SvelteKit,
     SvelteKitTs,
+    SolidStart,
+    SolidStartTs,
 }
 
 impl Default for Template {
@@ -65,6 +67,8 @@ impl Display for Template {
             Template::ClojureScript => write!(f, "clojurescript"),
             Template::SvelteKit => write!(f, "svelte-kit"),
             Template::SvelteKitTs => write!(f, "svelte-kit-ts"),
+            Template::SolidStart => write!(f, "solid-start"),
+            Template::SolidStartTs => write!(f, "solid-start-ts"),
         }
     }
 }
@@ -92,6 +96,8 @@ impl FromStr for Template {
             "clojurescript" => Ok(Template::ClojureScript),
             "svelte-kit" => Ok(Template::SvelteKit),
             "svelte-kit-ts" => Ok(Template::SvelteKitTs),
+            "solid-start" => Ok(Template::SolidStart),
+            "solid-start-ts" => Ok(Template::SolidStartTs),
             _ => Err("Invalid template".to_string()),
         }
     }
@@ -118,6 +124,8 @@ impl<'a> Template {
         Template::ClojureScript,
         Template::SvelteKit,
         Template::SvelteKitTs,
+        Template::SolidStart,
+        Template::SolidStartTs,
     ];
 
     pub fn post_init_info(&self, pkg_manager: PackageManager) -> Option<String> {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
	- [x] Template 

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

- I have choose to use the default port 3000 of Solid-Start because there is a [issue](https://github.com/solidjs/solid-start/issues/456) where the port specified in the Vite config is ignored
- There are files dedicated to ssr in the dist/public folder because if I set `ssr: false` in the Vite config the build would fail. (link to the [issue](https://github.com/solidjs/solid-start/issues/325))