### PR TITLE
fix: add typescript support in .svelte files

### DIFF
--- a/.changes/fix-typescript-in-svelte-and-sveltekit.md
+++ b/.changes/fix-typescript-in-svelte-and-sveltekit.md
@@ -2,6 +2,4 @@
 "create-tauri-app": patch
 ---
 
-Fixed an [issue](https://github.com/tauri-apps/create-tauri-app/issues/276) where typescript was not working inside .svelte files in the svelte-kit-ts and svelte-ts templates. In both cases, this was due to the lack of a preprocessor. This was fixed differently in each template.
-
-For sveltekit, the preprocessor was added to the svelte.config.js file. For svelte, the preprocessor was added to the vite.config.js file. For svelte, this required adding svelte-preprocess as a dev dependency.
+Add `svelte-process` preprocessor to `svelte-ts` and `svelte-kit-ts` templates by default so typescript can work correctly inside `.svelte` files.

--- a/.changes/fix-typescript-in-svelte-and-sveltekit.md
+++ b/.changes/fix-typescript-in-svelte-and-sveltekit.md
@@ -1,0 +1,7 @@
+---
+"create-tauri-app": patch
+---
+
+Fixed an [issue](https://github.com/tauri-apps/create-tauri-app/issues/276) where typescript was not working inside .svelte files in the svelte-kit-ts and svelte-ts templates. In both cases, this was due to the lack of a preprocessor. This was fixed differently in each template.
+
+For sveltekit, the preprocessor was added to the svelte.config.js file. For svelte, the preprocessor was added to the vite.config.js file. For svelte, this required adding svelte-preprocess as a dev dependency.

--- a/packages/cli/fragments/fragment-svelte-kit-ts/svelte.config.js
+++ b/packages/cli/fragments/fragment-svelte-kit-ts/svelte.config.js
@@ -1,7 +1,9 @@
 import staticAdapter from "@sveltejs/adapter-static";
+import { vitePreprocess } from "@sveltejs/kit/vite";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+  preprocess: [vitePreprocess()],
   kit: {
     adapter: staticAdapter(),
   },

--- a/packages/cli/fragments/fragment-svelte-ts/package.json
+++ b/packages/cli/fragments/fragment-svelte-ts/package.json
@@ -19,6 +19,7 @@
     "@tsconfig/svelte": "^3.0.0",
     "svelte": "^3.54.0",
     "svelte-check": "^2.10.0",
+    "svelte-preprocess": "^5.0.0",
     "tslib": "^2.4.1",
     "typescript": "^4.6.4",
     "vite": "^4.0.0",

--- a/packages/cli/fragments/fragment-svelte-ts/vite.config.ts
+++ b/packages/cli/fragments/fragment-svelte-ts/vite.config.ts
@@ -4,7 +4,15 @@ import sveltePreprocess from "svelte-preprocess";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svelte({ preprocess: [sveltePreprocess({ typescript: true })] })],
+  plugins: [
+    svelte({
+      preprocess: [
+        sveltePreprocess({
+          typescript: true,
+        }),
+      ],
+    }),
+  ],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   // prevent vite from obscuring rust errors

--- a/packages/cli/fragments/fragment-svelte-ts/vite.config.ts
+++ b/packages/cli/fragments/fragment-svelte-ts/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import sveltePreprocess from "svelte-preprocess";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte({ preprocess: [sveltePreprocess({ typescript: true })] })],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   // prevent vite from obscuring rust errors


### PR DESCRIPTION
enable and add preprocessor for sveltekit and svelte respectively

(fix #276)

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

In the Svelte and SvelteKit TypeScript templates, if TypeScript syntax is used inside a `.svelte` file, Vite will throw an error. For example, in a fresh SvelteKit project, if the code...

```svelte
<script lang="ts">
  import { invoke } from "@tauri-apps/api/tauri";

  let name = "";
  let greetMsg = "";

  let myBool: boolean;  // <-- line of interest(line 6)

  async function greet() {
    // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
    greetMsg = await invoke("greet", { name });
  }
</script>
```

...is in a `.svelte` file(here it is specifically line 6), the following error is seen:

```bash
2:55:52 PM [vite] Internal server error: /src/lib/Greet.svelte:6:12 Unexpected token
  Plugin: vite-plugin-svelte
  File: /src/lib/Greet.svelte:6:12
   4 |    let name = "";
   5 |    let greetMsg = "";
   6 |    let myBool: boolean;
                    ^
   7 |  
   8 |    async function greet() {
```

This error appears in both Svelte and SvelteKit, with brand new, freshly-created projects. The fixes I found differ between Svelte and SvelteKit. 

---

For **SvelteKit**, the `svelte.config.js` must be changed from this:

```js
import staticAdapter from "@sveltejs/adapter-static";

/** @type {import('@sveltejs/kit').Config} */
const config = {
  kit: {
    adapter: staticAdapter(),
  },
};

export default config;
```

...to this:

```js
import staticAdapter from "@sveltejs/adapter-static";
import { vitePreprocess } from "@sveltejs/kit/vite"; // <-- added this line

/** @type {import('@sveltejs/kit').Config} */
const config = {
  preprocess: [vitePreprocess()], // <-- and this line
  kit: {
    adapter: staticAdapter(),
  },
};

export default config;
```

In **Svelte**, the `package.json` file must be changed to add

```js
// ...
    "svelte-preprocess": "^5.0.0",
// ...
```

...to the devDependencies.

Further, the beginning of the `vite.config.ts` file must be changed from this:
```ts
import { defineConfig } from "vite";
import { svelte } from "@sveltejs/vite-plugin-svelte";

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [svelte()],
// ...
```

...to this:

```ts
import { defineConfig } from "vite";
import { svelte } from "@sveltejs/vite-plugin-svelte";
import sveltePreprocess from "svelte-preprocess"; // <-- added this

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [svelte({ preprocess: [sveltePreprocess({ typescript: true })] })], // <-- and this
// ...
```

Once these changes are made, TypeScript can be used as-expected within `.svelte` files, in both SvelteKit and Svelte.

---

This is my first ever pull request. Please let me know if I have done anything in error.