### PR TITLE
Update code snippets to use the platform

### DIFF
--- a/.changes/platform.md
+++ b/.changes/platform.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": "patch"
+"create-tauri-app-js": "patch"
+---
+
+Fix generated output to use HTML forms properly.

--- a/packages/cli/fragments/fragment-next-ts/src/pages/index.tsx
+++ b/packages/cli/fragments/fragment-next-ts/src/pages/index.tsx
@@ -57,16 +57,19 @@ function App() {
       <p>Click on the Tauri, Next, and React logos to learn more.</p>
 
       <div className="row">
-        <div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            greet();
+          }}
+        >
           <input
             id="greet-input"
             onChange={(e) => setName(e.currentTarget.value)}
             placeholder="Enter a name..."
           />
-          <button type="button" onClick={() => greet()}>
-            Greet
-          </button>
-        </div>
+          <button type="submit">Greet</button>
+        </form>
       </div>
 
       <p>{greetMsg}</p>

--- a/packages/cli/fragments/fragment-next/src/pages/index.jsx
+++ b/packages/cli/fragments/fragment-next/src/pages/index.jsx
@@ -57,16 +57,19 @@ function App() {
       <p>Click on the Tauri, Next, and React logos to learn more.</p>
 
       <div className="row">
-        <div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            greet();
+          }}
+        >
           <input
             id="greet-input"
             onChange={(e) => setName(e.currentTarget.value)}
             placeholder="Enter a name..."
           />
-          <button type="button" onClick={() => greet()}>
-            Greet
-          </button>
-        </div>
+          <button type="submit">Greet</button>
+        </form>
       </div>
 
       <p>{greetMsg}</p>

--- a/packages/cli/fragments/fragment-preact-ts/src/app.tsx
+++ b/packages/cli/fragments/fragment-preact-ts/src/app.tsx
@@ -30,16 +30,19 @@ export function App<FC>() {
       <p>Click on the Tauri, Vite, and Preact logos to learn more.</p>
 
       <div class="row">
-        <div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            greet();
+          }}
+        >
           <input
             id="greet-input"
             onChange={(e) => setName(e.currentTarget.value)}
             placeholder="Enter a name..."
           />
-          <button type="button" onClick={() => greet()}>
-            Greet
-          </button>
-        </div>
+          <button type="submit">Greet</button>
+        </form>
       </div>
       <p>{greetMsg}</p>
     </div>

--- a/packages/cli/fragments/fragment-preact/src/app.jsx
+++ b/packages/cli/fragments/fragment-preact/src/app.jsx
@@ -30,16 +30,19 @@ export function App() {
       <p>Click on the Tauri, Vite, and Preact logos to learn more.</p>
 
       <div class="row">
-        <div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            greet();
+          }}
+        >
           <input
             id="greet-input"
             onChange={(e) => setName(e.currentTarget.value)}
             placeholder="Enter a name..."
           />
-          <button type="button" onClick={() => greet()}>
-            Greet
-          </button>
-        </div>
+          <button type="submit">Greet</button>
+        </form>
       </div>
       <p>{greetMsg}</p>
     </div>

--- a/packages/cli/fragments/fragment-react-ts/src/App.tsx
+++ b/packages/cli/fragments/fragment-react-ts/src/App.tsx
@@ -31,16 +31,19 @@ function App() {
       <p>Click on the Tauri, Vite, and React logos to learn more.</p>
 
       <div className="row">
-        <div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            greet();
+          }}
+        >
           <input
             id="greet-input"
             onChange={(e) => setName(e.currentTarget.value)}
             placeholder="Enter a name..."
           />
-          <button type="button" onClick={() => greet()}>
-            Greet
-          </button>
-        </div>
+          <button type="submit">Greet</button>
+        </form>
       </div>
       <p>{greetMsg}</p>
     </div>

--- a/packages/cli/fragments/fragment-react/src/App.jsx
+++ b/packages/cli/fragments/fragment-react/src/App.jsx
@@ -31,16 +31,19 @@ function App() {
       <p>Click on the Tauri, Vite, and React logos to learn more.</p>
 
       <div className="row">
-        <div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            greet();
+          }}
+        >
           <input
             id="greet-input"
             onChange={(e) => setName(e.currentTarget.value)}
             placeholder="Enter a name..."
           />
-          <button type="button" onClick={() => greet()}>
-            Greet
-          </button>
-        </div>
+          <button type="submit">Greet</button>
+        </form>
       </div>
 
       <p>{greetMsg}</p>

--- a/packages/cli/fragments/fragment-solid/src/App.jsx
+++ b/packages/cli/fragments/fragment-solid/src/App.jsx
@@ -31,16 +31,19 @@ function App() {
       <p>Click on the Tauri, Vite, and Solid logos to learn more.</p>
 
       <div class="row">
-        <div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            greet();
+          }}
+        >
           <input
             id="greet-input"
             onChange={(e) => setName(e.currentTarget.value)}
             placeholder="Enter a name..."
           />
-          <button type="button" onClick={() => greet()}>
-            Greet
-          </button>
-        </div>
+          <button type="submit">Greet</button>
+        </form>
       </div>
 
       <p>{greetMsg}</p>


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### Why

Currently, the default greeter Tauri app when using the quickstart does not ship a valid HTML form. This is evidenced by nothing happening when pressing "Enter" after typing a name in the name input field:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/9947422/218494530-522f797e-bc66-424c-a082-fa744ce25a6f.png">

This PR uses proper HTML `form` elements and their `onsubmit` handler to have the greeter actually submit a form on Enter, instead of a button receiving a click event only in isolation. I feel this is important as it _teaches newcomers_ stuff and we want to teach them the right stuff.

### Caveat

This PR doesn't touch the `yew` template because I don't know Rust and I'm not sure how to `e.preventDefault` in an `onsubmit` handler with Yew. We can treat Yew separately in #332.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
