### PR TITLE
feat: Use Js/Ts instead of Rust as the default frontend language

### DIFF
--- a/packages/cli/src/category.rs
+++ b/packages/cli/src/category.rs
@@ -2,20 +2,16 @@ use std::fmt::Display;
 
 use crate::package_manager::PackageManager;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum Category {
     Rust,
+    #[default]
     JsTs,
-}
-impl Default for Category {
-    fn default() -> Self {
-        Category::Rust
-    }
 }
 
 impl<'a> Category {
-    pub const ALL: &'a [Self] = &[Category::Rust, Category::JsTs];
+    pub const ALL: &'a [Self] = &[Category::JsTs, Category::Rust];
 
     pub const fn package_managers(&self) -> &[PackageManager] {
         match self {

--- a/packages/cli/src/category.rs
+++ b/packages/cli/src/category.rs
@@ -2,12 +2,16 @@ use std::fmt::Display;
 
 use crate::package_manager::PackageManager;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Category {
     Rust,
-    #[default]
     JsTs,
+}
+impl Default for Category {
+    fn default() -> Self {
+        Category::JsTs
+    }
 }
 
 impl<'a> Category {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
From how I see it, `create-tauri-app` is more beginner-focused rather than for advanced users, so the default options should be the easy ones.

Therefore, I think it makes sense to show `JavaScript / TypeScript` as the default frontend language rather than `Rust`

![imagen](https://user-images.githubusercontent.com/38158676/229299509-b78f2d15-5d8a-4146-bc67-7f5e0c992710.png)


Let me know what you think 👍 