### PR TITLE
feat: make greet() functional from a web browser

### DIFF
--- a/packages/cli/fragments/fragment-vanilla-ts/src/main.ts
+++ b/packages/cli/fragments/fragment-vanilla-ts/src/main.ts
@@ -3,12 +3,21 @@ import { invoke } from "@tauri-apps/api/tauri";
 let greetInputEl: HTMLInputElement | null;
 let greetMsgEl: HTMLElement | null;
 
+function isTauri() {
+  return typeof window !== "undefined" && "__TAURI__" in window;
+}
+
 async function greet() {
-  if (greetMsgEl && greetInputEl) {
-    // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
-    greetMsgEl.textContent = await invoke("greet", {
-      name: greetInputEl.value,
-    });
+  if (greetMsgEl && greetInputEl && greetInputEl.value.length > 0) {
+    if (isTauri()) {
+      // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
+      greetMsgEl.textContent = await invoke("greet", {
+        name: greetInputEl.value,
+      });
+      return;
+    }
+
+    greetMsgEl.textContent = `Hello, ${greetInputEl.value}! You've been greeted from TypeScript!`;
   }
 }
 


### PR DESCRIPTION
By default, this template only works when running `npm run tauri`. For scalability, adding a quick check and making it function with just TypeScript may be a good idea.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
