### PR TITLE
fix(cta-js): rename arguments to args due to strict mode

### DIFF
--- a/.changes/js-strict.md
+++ b/.changes/js-strict.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": "patch"
+---
+
+Fix running `create-tauri-app` in JS environments in strict mode.

--- a/packages/cli/node/create-tauri-app.js
+++ b/packages/cli/node/create-tauri-app.js
@@ -7,7 +7,7 @@
 const cli = require("./index");
 const path = require("path");
 
-const [bin, script, ...arguments] = process.argv;
+const [bin, script, ...args] = process.argv;
 const binStem = path.parse(bin).name.toLowerCase();
 
 // We want to make a helpful binary name for the underlying CLI helper, if we
@@ -46,7 +46,7 @@ if (binStem.match(/(nodejs|node)-*([1-9]*)*$/g)) {
   }
 } else {
   // We don't know what started it, assume it's already stripped.
-  arguments.unshift(bin);
+  args.unshift(bin);
 }
 
-cli.run(arguments, binName);
+cli.run(args, binName);


### PR DESCRIPTION
I stumbled upon this error:

```sh
error: Declarations with the name arguments cannot be used with esm due to strict mode

const [bin, script, ...arguments] = process.argv;
                       ^
/private/tmp/create-tauri-app@latest--bunx/node_modules/create-tauri-app/create-tauri-app.js:10:24 249
error: "create-tauri-app" exited with code 1 (SIGHUP)
```

Context here:
https://github.com/oven-sh/bun/issues/3237#issuecomment-1650169840

The solution is to rename arguments to args or anything else really. This can be verified by adding `"use strict";` to the top of the file.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
