### PR TITLE
feat: skip `.git` when overwriting an existing directory

### DIFF
--- a/.changes/skip-git-directory.md
+++ b/.changes/skip-git-directory.md
@@ -1,0 +1,7 @@
+---
+"create-tauri-app": "patch"
+"create-tauri-app-js": "patch"
+---
+
+Skip deleting `.git` directory when initalizing a project in an already existing directoy.
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["packages/cli", "packages/cli/node"]
 
 [profile.release]

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -269,12 +269,15 @@ where
     // Remove the target dir contents before rendering the template
     // SAFETY: Upon reaching this line, the user already accepted to overwrite
     if target_dir.exists() {
+        #[inline(always)]
         fn clean_dir(dir: &std::path::PathBuf) -> anyhow::Result<()> {
             for entry in fs::read_dir(dir)?.flatten() {
                 let path = entry.path();
                 if entry.file_type()?.is_dir() {
-                    clean_dir(&path)?;
-                    std::fs::remove_dir(path)?;
+                    if entry.file_name() != ".git" {
+                        clean_dir(&path)?;
+                        std::fs::remove_dir(path)?;
+                    }
                 } else {
                     fs::remove_file(path)?;
                 }


### PR DESCRIPTION
closes #483

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
