### PR TITLE
fix: handle SIGINT on user prompt, closes (#509)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.1"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
+checksum = "7394a21d012ce5c850497fb774b167d81b99f060025fbf06ee92b9848bd97eb2"
 dependencies = [
  "nix",
  "windows-sys 0.48.0",
@@ -412,11 +412,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.0.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -101,6 +101,7 @@ name = "create-tauri-app"
 version = "3.9.0"
 dependencies = [
  "anyhow",
+ "ctrlc",
  "dialoguer",
  "pico-args",
  "rust-embed",
@@ -134,6 +135,16 @@ checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
  "syn 2.0.18",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
+dependencies = [
+ "nix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -296,9 +307,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libflate"
@@ -348,7 +359,7 @@ version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16752bb7506f04f3aa6e5a6b783032059edb49e61c3bdb81d4b2949e58029822"
 dependencies = [
- "bitflags 2.0.2",
+ "bitflags 2.4.1",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -397,6 +408,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "166b5ef52a3ab5575047a9fe8d4a030cdd0f63c96f071cd6907674453b07bae3"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -708,13 +730,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -723,7 +745,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -732,13 +763,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -748,10 +794,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -760,10 +818,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -772,16 +842,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zeroize"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -20,4 +20,5 @@ path = "src/main.rs"
 anyhow = "1"
 dialoguer = "0.10"
 pico-args = "0.5"
+ctrlc = "3.4.1"
 rust-embed = { version = "8.0", features = [ "compression", "interpolate-folder-path" ] }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/main.rs"
 anyhow = "1"
 dialoguer = "0.10"
 pico-args = "0.5"
-ctrlc = "=3.3.1"
+ctrlc = "3.3"
 rust-embed = { version = "8.0", features = [ "compression", "interpolate-folder-path" ] }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -20,5 +20,5 @@ path = "src/main.rs"
 anyhow = "1"
 dialoguer = "0.10"
 pico-args = "0.5"
-ctrlc = "3.4.1"
+ctrlc = "=3.3.1"
 rust-embed = { version = "8.0", features = [ "compression", "interpolate-folder-path" ] }

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -41,6 +41,7 @@ where
     I: IntoIterator<Item = A>,
     A: Into<OsString> + Clone,
 {
+    ctrlc::set_handler(move || eprint!("\x1b[?25h")).expect("fail to set SIGINT handler");
     if let Err(e) = try_run(args, bin_name, detected_manager) {
         eprintln!("{BOLD}{RED}error{RESET}: {e:#}");
         exit(1);
@@ -86,7 +87,9 @@ where
         Some(name) => name,
         None => {
             if skip {
-                defaults.project_name.context("project_name not defined")?
+                defaults
+                    .project_name
+                    .context("default project_name not set")?
             } else {
                 Input::<String>::with_theme(&ColorfulTheme::default())
                     .with_prompt("Project name")
@@ -207,9 +210,9 @@ where
         Some(manager) => manager,
         None => {
             if skip {
-                defaults.manager.context("manager not set")?
+                defaults.manager.context("default manager not set")?
             } else {
-                let category = category.context("category not set")?;
+                let category = category.context("category shouldn't be None at this point")?;
 
                 let mut managers = category.package_managers().to_owned();
                 // sort managers so the auto-detected package manager is selected first
@@ -241,7 +244,7 @@ where
         Some(template) => template,
         None => {
             if skip {
-                defaults.template.context("template not set")?
+                defaults.template.context("default template not set")?
             } else {
                 let index = Select::with_theme(&ColorfulTheme::default())
                     .with_prompt("Choose your UI template")
@@ -279,7 +282,7 @@ where
         Some(mobile) => mobile,
         None => {
             if skip || !alpha {
-                defaults.mobile.unwrap()
+                defaults.mobile.context("default mobile not set")?
             } else {
                 Confirm::with_theme(&ColorfulTheme::default())
                     .with_prompt("Would you like to setup the project for mobile as well?")

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use anyhow::Context;
 use dialoguer::{Confirm, Input, Select};
 use std::{ffi::OsString, fs, process::exit};
 
@@ -81,19 +82,21 @@ where
 
     // Project name used for the project directory name
     // and if valid, it will also be used in Cargo.toml, Package.json ...etc
-    let project_name = project_name.unwrap_or_else(|| {
-        if skip {
-            defaults.project_name.unwrap()
-        } else {
-            Input::<String>::with_theme(&ColorfulTheme::default())
-                .with_prompt("Project name")
-                .default("tauri-app".into())
-                .interact_text()
-                .unwrap()
-                .trim()
-                .to_string()
+    let project_name = match project_name {
+        Some(name) => name,
+        None => {
+            if skip {
+                defaults.project_name.context("project_name not defined")?
+            } else {
+                Input::<String>::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Project name")
+                    .default("tauri-app".into())
+                    .interact_text()?
+                    .trim()
+                    .into()
+            }
         }
-    });
+    };
 
     let target_dir = cwd.join(&project_name);
 
@@ -191,8 +194,7 @@ where
                 .with_prompt("Choose which language to use for your frontend")
                 .items(&categories)
                 .default(0)
-                .interact()
-                .unwrap();
+                .interact()?;
             Some(categories[index])
         }
     } else {
@@ -201,86 +203,91 @@ where
 
     // Package manager which will be used for rendering the template
     // and the after-render instructions
-    let pkg_manager = manager.unwrap_or_else(|| {
-        if skip {
-            defaults.manager.unwrap()
-        } else {
-            let category = category.unwrap();
-
-            let mut managers = category.package_managers().to_owned();
-            // sort managers so the auto-detected package manager is selected first
-            managers.sort_by(|a, b| {
-                detected_manager
-                    .map(|p| p == *b)
-                    .unwrap_or(false)
-                    .cmp(&detected_manager.map(|p| p == *a).unwrap_or(false))
-            });
-
-            // If only one package manager is detected, skip prompt
-            if managers.len() == 1 {
-                managers[0]
+    let pkg_manager = match manager {
+        Some(manager) => manager,
+        None => {
+            if skip {
+                defaults.manager.context("manager not set")?
             } else {
-                let index = Select::with_theme(&ColorfulTheme::default())
-                    .with_prompt("Choose your package manager")
-                    .items(&managers)
-                    .default(0)
-                    .interact()
-                    .unwrap();
-                managers[index]
+                let category = category.context("category not set")?;
+
+                let mut managers = category.package_managers().to_owned();
+                // sort managers so the auto-detected package manager is selected first
+                managers.sort_by(|a, b| {
+                    detected_manager
+                        .map(|p| p == *b)
+                        .unwrap_or(false)
+                        .cmp(&detected_manager.map(|p| p == *a).unwrap_or(false))
+                });
+                // If only one package manager is detected, skip prompt
+                if managers.len() == 1 {
+                    managers[0]
+                } else {
+                    let index = Select::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Choose your package manager")
+                        .items(&managers)
+                        .default(0)
+                        .interact()?;
+                    managers[index]
+                }
             }
         }
-    });
+    };
 
     let templates_no_flavors = pkg_manager.templates_no_flavors();
 
     // Template to render
-    let template = template.unwrap_or_else(|| {
-        if skip {
-            defaults.template.unwrap()
-        } else {
-            let index = Select::with_theme(&ColorfulTheme::default())
-                .with_prompt("Choose your UI template")
-                .items(
-                    &templates_no_flavors
-                        .iter()
-                        .map(|t| t.select_text())
-                        .collect::<Vec<_>>(),
-                )
-                .default(0)
-                .interact()
-                .unwrap();
-            let template = templates_no_flavors[index];
-
-            // Prompt for flavors if the template has more than one flavor
-            let flavors = template.flavors(pkg_manager);
-            if let Some(flavors) = flavors {
-                let index = Select::with_theme(&ColorfulTheme::default())
-                    .with_prompt("Choose your UI flavor")
-                    .items(flavors)
-                    .default(0)
-                    .interact()
-                    .unwrap();
-                template.from_flavor(flavors[index])
+    let template = match template {
+        Some(template) => template,
+        None => {
+            if skip {
+                defaults.template.context("template not set")?
             } else {
-                template
+                let index = Select::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Choose your UI template")
+                    .items(
+                        &templates_no_flavors
+                            .iter()
+                            .map(|t| t.select_text())
+                            .collect::<Vec<_>>(),
+                    )
+                    .default(0)
+                    .interact()?;
+
+                let template = templates_no_flavors[index];
+
+                // Prompt for flavors if the template has more than one flavor
+                let flavors = template.flavors(pkg_manager);
+                if let Some(flavors) = flavors {
+                    let index = Select::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Choose your UI flavor")
+                        .items(flavors)
+                        .default(0)
+                        .interact()?;
+                    template.from_flavor(flavors[index])
+                } else {
+                    template
+                }
             }
         }
-    });
+    };
 
     // Prompt for wether to bootstrap a mobile-friendly tauri project
     // This should only be prompted if `--alpha` is used on the command line and `--mobile` wasn't.
     // TODO: remove this limitation once tauri@v2 is stable
-    let mobile = mobile.unwrap_or_else(|| {
-        if skip || !alpha {
-            defaults.mobile.unwrap()
-        } else {
-            Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt("Would you like to setup the project for mobile as well?")
-                .default(false)
-                .interact()
-                .unwrap()
+    let mobile = match mobile {
+        Some(mobile) => mobile,
+        None => {
+            if skip || !alpha {
+                defaults.mobile.unwrap()
+            } else {
+                Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Would you like to setup the project for mobile as well?")
+                    .default(false)
+                    .interact()?
+            }
         }
-    });
+    };
 
     // If the package manager and the template are specified on the command line
     // then almost all prompts are skipped so we need to make sure that the combination

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -5,6 +5,8 @@
 use std::{env::args_os, ffi::OsStr, path::Path};
 
 fn main() {
+    ctrlc::set_handler(move || eprint!("\x1b[?25h")).expect("fail to set SIGINT handler");
+
     let mut args = args_os().peekable();
     let mut is_cargo = false;
     let bin_name = match args

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -5,8 +5,6 @@
 use std::{env::args_os, ffi::OsStr, path::Path};
 
 fn main() {
-    ctrlc::set_handler(move || eprint!("\x1b[?25h")).expect("fail to set SIGINT handler");
-
     let mut args = args_os().peekable();
     let mut is_cargo = false;
     let bin_name = match args


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

In reference to #509, this PR adds a SIGINT handler using the `ctrlc` crate (though I'm not 100% sold on this crate, it seems to be de-facto way to handle SIGINT on Rust programs). Some of the logic of the prompts is also changed as to not die on `unwrap`.

Since dialoguer seems to be only hiding the cursor, and not changing the termios state, I think for now we only need to re-enable the cursor.
