### PR TITLE
fix: cargo.toml format when mobile feature enabled

### DIFF
--- a/.changes/fix-cargo-toml-format-with-mobile.md
+++ b/.changes/fix-cargo-toml-format-with-mobile.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+Fix an incorrect format in `src-tauri/Cargo.toml` when mobile feature enabled.

--- a/packages/cli/fragments/_base_/src-tauri/Cargo.toml.lts
+++ b/packages/cli/fragments/_base_/src-tauri/Cargo.toml.lts
@@ -11,7 +11,9 @@ edition = "2021"
 
 {% if mobile %}[lib]
 name = "{% lib_name %}"
-crate-type = ["staticlib", "cdylib", "rlib"]{% endif %}{% if stable %}[build-dependencies]
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+{% endif %}{% if stable %}[build-dependencies]
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

When using alpha version with mobile feature enabled, `Cargo.toml` will be like:

```toml
[lib]
name = "mmm_lib"
crate-type = ["staticlib", "cdylib", "rlib"][build-dependencies]
tauri-build = { version = "2.0.0-alpha", features = [] }
```
