### PR TITLE
fix: update vitejs/plugin-react to prevent peer dependency warning

### DIFF
--- a/.changes/vite-plugin-react.md
+++ b/.changes/vite-plugin-react.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Upgrade `@vitejs/plugin-react` to `4.2.1` to fix peer depenency for react templates.

--- a/packages/cli/fragments/fragment-react-ts/package.json.lts
+++ b/packages/cli/fragments/fragment-react-ts/package.json.lts
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
-    "@vitejs/plugin-react": "^4.0.3",
+    "@vitejs/plugin-react": "^4.2.1",
     "typescript": "^5.0.2",
     "vite": "^5.0.0",
     "@tauri-apps/cli": "^{% if alpha %}2.0.0-alpha.20{% else %}1.5.8{% endif %}"{% if mobile %},

--- a/packages/cli/fragments/fragment-react/package.json.lts
+++ b/packages/cli/fragments/fragment-react/package.json.lts
@@ -16,7 +16,7 @@
     "@tauri-apps/plugin-shell": "^2.0.0-alpha.3"{% endif %}
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.3",
+    "@vitejs/plugin-react": "^4.2.1",
     "vite": "^5.0.0",
     "@tauri-apps/cli": "^{% if alpha %}2.0.0-alpha.20{% else %}1.5.8{% endif %}"{% if mobile %},
     "internal-ip": "^7.0.0"{% endif %}


### PR DESCRIPTION
I recently created a new Tauri project using React and TS. After installing with pnpm, I encountered this warning:

```
 WARN  Issues with peer dependencies found
.
└─┬ @vitejs/plugin-react 4.0.3
  └── ✕ unmet peer vite@^4.2.0: found 5.0.0
```

`@vitejs/plugin-react` 4.0.3 has a dependency on vite 4.x. Updating to 4.2.1 of the plugin fixes this warning.
