### PR TITLE
feat: Use Vite with SWC

### DIFF
--- a/.changes/changes.md
+++ b/.changes/changes.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": minor
+---
+
+Vite with SWC in React templates.

--- a/templates/template-react-ts/package.json.lte
+++ b/templates/template-react-ts/package.json.lte
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react-swc": "^3.5.0",
     "typescript": "^5.0.2",
     "vite": "^5.0.0",
     "@tauri-apps/cli": "^{% if alpha %}2.0.0-alpha.20{% else %}1.5.8{% endif %}"{% if mobile %},

--- a/templates/template-react-ts/vite.config.ts.lte
+++ b/templates/template-react-ts/vite.config.ts.lte
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";{% if mobile %}
+import react from "@vitejs/plugin-react-swc";{% if mobile %}
 import { internalIpV4 } from "internal-ip";
 
 // @ts-expect-error process is a nodejs global

--- a/templates/template-react/package.json.lte
+++ b/templates/template-react/package.json.lte
@@ -16,7 +16,7 @@
     "@tauri-apps/plugin-shell": "^2.0.0-alpha.3"{% endif %}
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react-swc": "^3.5.0",
     "vite": "^5.0.0",
     "@tauri-apps/cli": "^{% if alpha %}2.0.0-alpha.20{% else %}1.5.8{% endif %}"{% if mobile %},
     "internal-ip": "^7.0.0"{% endif %}

--- a/templates/template-react/vite.config.js.lte
+++ b/templates/template-react/vite.config.js.lte
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";{% if mobile %}
+import react from "@vitejs/plugin-react-swc";{% if mobile %}
 import { internalIpV4 } from "internal-ip";
 
 const mobile = !!/android|ios/.exec(process.env.TAURI_ENV_PLATFORM);{% endif %}


### PR DESCRIPTION
Use Vite with SWC for React templates.

I have not tested any mobile builds using the plugin.

Documentation for the plugin is available [here](https://www.npmjs.com/package/@vitejs/plugin-react-swc).
