### PR TITLE
fix: add crate-type staticlib for mobile build

### DIFF
--- a/.changes/fix-cargo-toml-mobile-add-staticlib.md
+++ b/.changes/fix-cargo-toml-mobile-add-staticlib.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+Add crate-type `staticlib` to `Cargo.toml` for mobile builds.

--- a/templates/_base_/src-tauri/Cargo.toml.lte
+++ b/templates/_base_/src-tauri/Cargo.toml.lte
@@ -9,7 +9,7 @@ edition = "2021"
 
 {% if mobile %}[lib]
 name = "{% lib_name %}"
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 
 {% endif %}{% if stable %}[build-dependencies]
 tauri-build = { version = "1.5", features = [] }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->

iOS build needs to generate its static library and link it.

Error message without `staticlib`
```sh
Error [tauri_cli] Library not found at /Users/jason/Documents/recipies-test/src-tauri/target/aarch64-apple-ios-sim/debug/librecipies_test_lib.a. Make sure your Cargo.toml file has a [lib] block with `crate-type = ["staticlib", "cdylib", "rlib"]`
Command PhaseScriptExecution failed with a nonzero exit code
```


