### PR TITLE
fix: change package.json template plugin-shell version

### DIFF
--- a/.changes/plugin-shell.md
+++ b/.changes/plugin-shell.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Fixed `@tauri-apps/plugin-shell` version in generated templates.

--- a/templates/template-angular/package.json.lte
+++ b/templates/template-angular/package.json.lte
@@ -22,7 +22,7 @@
     "tslib": "^2.3.0",
     "zone.js": "~0.14.2",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.0.0",

--- a/templates/template-preact-ts/package.json.lte
+++ b/templates/template-preact-ts/package.json.lte
@@ -12,7 +12,7 @@
   "dependencies": {
     "preact": "^10.16.0",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.5.0",

--- a/templates/template-preact/package.json.lte
+++ b/templates/template-preact/package.json.lte
@@ -12,7 +12,7 @@
   "dependencies": {
     "preact": "^10.16.0",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.5.0",

--- a/templates/template-react-ts/package.json.lte
+++ b/templates/template-react-ts/package.json.lte
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/templates/template-react/package.json.lte
+++ b/templates/template-react/package.json.lte
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/templates/template-solid-ts/package.json.lte
+++ b/templates/template-solid-ts/package.json.lte
@@ -14,7 +14,7 @@
   "dependencies": {
     "solid-js": "^1.7.8",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "typescript": "^5.0.2",

--- a/templates/template-solid/package.json.lte
+++ b/templates/template-solid/package.json.lte
@@ -14,7 +14,7 @@
   "dependencies": {
     "solid-js": "^1.7.8",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/templates/template-svelte-ts/package.json.lte
+++ b/templates/template-svelte-ts/package.json.lte
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.1",

--- a/templates/template-svelte/package.json.lte
+++ b/templates/template-svelte/package.json.lte
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.1",

--- a/templates/template-vanilla-ts/package.json.lte
+++ b/templates/template-vanilla-ts/package.json.lte
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@tauri-apps/cli": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if mobile %},

--- a/templates/template-vue-ts/package.json.lte
+++ b/templates/template-vue-ts/package.json.lte
@@ -12,7 +12,7 @@
   "dependencies": {
     "vue": "^3.3.4",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",

--- a/templates/template-vue/package.json.lte
+++ b/templates/template-vue/package.json.lte
@@ -12,7 +12,7 @@
   "dependencies": {
     "vue": "^3.3.4",
     "@tauri-apps/api": "{% if alpha %}>=2.0.0-beta.0{% else %}^1{% endif %}"{% if alpha %},
-    "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0"{% endif %}
+    "@tauri-apps/plugin-shell": ">=2.0.0-beta.0"{% endif %}
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",


### PR DESCRIPTION
```bash  cargo create-tauri-app --beta ```
 
 ```bash
✔ Project name · hexo-book
✔ Choose which language to use for your frontend · TypeScript / JavaScript - (pnpm, yarn, npm, bun)
✔ Choose your package manager · pnpm
✔ Choose your UI template · React - (https://react.dev/)
✔ Choose your UI flavor · TypeScript
✔ Would you like to setup the project for mobile as well? · yes
```
 ```bash pnpm install```
  
Error:
 ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER  @tauri-apps/plugin-shell@^>=2.0.0-beta.0 isn't supported by any available resolver.

I found "@tauri-apps/plugin-shell": "^>=2.0.0-beta.0" in package.json.

it is problem?
