### PR TITLE
chore(cli): remove duplicate 'directory' in error msg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ where
                 .with_prompt(format!(
                     "{} directory is not empty, do you want to overwrite?",
                     if target_dir == cwd {
-                        "Current directory".to_string()
+                        "Current".to_string()
                     } else {
                         target_dir
                             .file_name()


### PR DESCRIPTION
Example situation where this crops up:
```
✔ Project name · ./
✔ Package name · rusted-iron
✔ Current directory directory is not empty, do you want to overwrite? · no
✘ Directory is not empty, Operation Cancelled
```