### PR TITLE
fix: Remove deprecated serde-serialize feature flag.

### DIFF
--- a/.changes/remove-serde-serialize-feat.md
+++ b/.changes/remove-serde-serialize-feat.md
@@ -1,0 +1,6 @@
+---
+create-tauri-app: patch
+create-tauri-app-js: patch
+---
+
+Removed the deprecated `serde-serialize` feature of `wasm-bindgen` in favor of `serde-wasm-bindgen` to prevent cyclic dependency issues.

--- a/templates/template-leptos/Cargo.toml.lte
+++ b/templates/template-leptos/Cargo.toml.lte
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 leptos = { version = "0.5", features = ["csr"] }
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/templates/template-sycamore/Cargo.toml.lte
+++ b/templates/template-sycamore/Cargo.toml.lte
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 sycamore = { version = "0.8", features = ["suspense"] }
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.4"

--- a/templates/template-yew/Cargo.toml.lte
+++ b/templates/template-yew/Cargo.toml.lte
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
 js-sys = "0.3"


### PR DESCRIPTION
ref https://github.com/tauri-apps/tauri/issues/9150

I'm not really a rust frontend user so i'm not 100% sure this won't break anything but in the code we already had the correct dependency and in none of the issue about cyclic dependencies did they ever list a reason to keep the feature instead of using the seperate crate.