### PR TITLE
feat: add `console_error_panic_hook` to Rust templates

### DIFF
--- a/.changes/rust-templates-console-error-panic-hook.md
+++ b/.changes/rust-templates-console-error-panic-hook.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Add `console_error_panic_hook` to `yew`, `leptos` and `sycamore` templates.

--- a/templates/template-leptos/Cargo.toml.lte
+++ b/templates/template-leptos/Cargo.toml.lte
@@ -11,6 +11,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
+console_error_panic_hook = "0.1.7"
 
 [workspace]
 members = ["src-tauri"]

--- a/templates/template-leptos/src/main.rs
+++ b/templates/template-leptos/src/main.rs
@@ -2,7 +2,6 @@ mod app;
 
 use app::*;
 use leptos::*;
-use console_error_panic_hook;
 
 fn main() {
     console_error_panic_hook::set_once();

--- a/templates/template-leptos/src/main.rs
+++ b/templates/template-leptos/src/main.rs
@@ -2,8 +2,10 @@ mod app;
 
 use app::*;
 use leptos::*;
+use console_error_panic_hook;
 
 fn main() {
+    console_error_panic_hook::set_once();
     mount_to_body(|| {
         view! {
             <App/>

--- a/templates/template-sycamore/Cargo.toml.lte
+++ b/templates/template-sycamore/Cargo.toml.lte
@@ -11,6 +11,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.4"
 serde = { version = "1", features = ["derive"] }
+console_error_panic_hook = "0.1.7"
 
 [workspace]
 members = ["src-tauri"]

--- a/templates/template-sycamore/src/main.rs
+++ b/templates/template-sycamore/src/main.rs
@@ -3,5 +3,6 @@ mod app;
 use app::App;
 
 fn main() {
+    console_error_panic_hook::set_once();
     sycamore::render(App);
 }

--- a/templates/template-yew/Cargo.toml.lte
+++ b/templates/template-yew/Cargo.toml.lte
@@ -12,6 +12,7 @@ web-sys = "0.3"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
+console_error_panic_hook = "0.1.7"
 
 [workspace]
 members = ["src-tauri"]

--- a/templates/template-yew/src/main.rs
+++ b/templates/template-yew/src/main.rs
@@ -3,5 +3,6 @@ mod app;
 use app::App;
 
 fn main() {
+    console_error_panic_hook::set_once();
     yew::Renderer::<App>::new().render();
 }


### PR DESCRIPTION
Using `console_error_panic_hook` allows for easier debugging, as it allows you to see the error message when something panics.