### PR TITLE
chore(leptos-template): bump leptos from 0.5 to 0.6

### DIFF
--- a/.changes/changes.md
+++ b/.changes/changes.md
@@ -1,0 +1,7 @@
+---
+"create-tauri-app": patch
+---
+
+This PR simply updates the version of leptos from `0.5` to `0.6` in the leptos template.
+
+This upgrade does not break the existing code in the template, so it's a drop in replacement.

--- a/.changes/changes.md
+++ b/.changes/changes.md
@@ -1,7 +1,6 @@
 ---
 "create-tauri-app": patch
+"create-tauri-app-js": patch
 ---
 
-This PR simply updates the version of leptos from `0.5` to `0.6` in the leptos template.
-
-This upgrade does not break the existing code in the template, so it's a drop in replacement.
+Update `leptos` template to `v0.6`

--- a/templates/template-leptos/Cargo.toml.lte
+++ b/templates/template-leptos/Cargo.toml.lte
@@ -1,11 +1,11 @@
 [package]
-name = "{% package_name %}-ui"
+name = "tauri-app-ui"
 version = "0.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-leptos = { version = "0.5", features = ["csr"] }
+leptos = { version = "0.6", features = ["csr"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/templates/template-leptos/Cargo.toml.lte
+++ b/templates/template-leptos/Cargo.toml.lte
@@ -1,5 +1,5 @@
 [package]
-name = "tauri-app-ui"
+name = "{% package_name %}-ui"
 version = "0.0.0"
 edition = "2021"
 


### PR DESCRIPTION
This PR simply updates the version of leptos from `0.5` to `0.6` in the leptos template.

This upgrade does not break the existing code in the template, so it's a drop in replacement.