### PR TITLE
feat: adds rust-toolchain.toml

### DIFF
--- a/templates/_base_/src-tauri/%(beta-mobile)%rust-toolchain.toml
+++ b/templates/_base_/src-tauri/%(beta-mobile)%rust-toolchain.toml
@@ -1,0 +1,20 @@
+[toolchain]
+channel = "1.77.2"
+profile = "minimal"
+components = [
+  "cargo",
+  "clippy",
+  "llvm-tools-preview",
+  "rustc",
+  "rust-src",
+  "rustfmt",
+]
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    "aarch64-apple-ios-sim",
+]

--- a/templates/_base_/src-tauri/%(stable)%rust-toolchain.toml
+++ b/templates/_base_/src-tauri/%(stable)%rust-toolchain.toml
@@ -1,0 +1,12 @@
+[toolchain]
+channel = "1.77.2"
+profile = "minimal"
+components = [
+  "cargo",
+  "clippy",
+  "llvm-tools-preview",
+  "rustc",
+  "rust-src",
+  "rustfmt",
+]
+targets = []


### PR DESCRIPTION
In relation to the CVE about Rust it's about time we pulled the trigger on adding `rust-toolchain.toml` in project templates. The reasoning behind this is pretty simple, it's good practice in projects in general to have one to enforce all developers to use the same Rust version, but more importantly it makes it very easy for projects to update their toolchain version when things like this happens. Furthermore it makes it more relevant for us to develop a `tauri audit --fix` command that checks the version in `rust-toolchain.toml` and recommends updating it.
