### PR TITLE
fixed image paths in vanilla template

### DIFF
--- a/templates/template-vanilla/src/index.html
+++ b/templates/template-vanilla/src/index.html
@@ -19,14 +19,14 @@
 
       <div class="row">
         <a href="https://tauri.app" target="_blank">
-          <img src="/assets/tauri.svg" class="logo tauri" alt="Tauri logo" />
+          <img src="./assets/tauri.svg" class="logo tauri" alt="Tauri logo" />
         </a>
         <a
           href="https://developer.mozilla.org/en-US/docs/Web/JavaScript"
           target="_blank"
         >
           <img
-            src="/assets/javascript.svg"
+            src="./assets/javascript.svg"
             class="logo vanilla"
             alt="JavaScript logo"
           />


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->
fixes #674 by making the image paths relative. I believe this change makes more sense to someone entirely new to js as a beginner might not understand why the images are not loading when opening it with a browser but it loads successfully when using `cargo tauri dev` server.