### PR TITLE
fix: add missing body element for rust template

### DIFF
--- a/.changes/rust-template-body.md
+++ b/.changes/rust-template-body.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Fix `yew`, `leptos` and `sycamore` templates failing with latest versions of `trunk` CLI. 

--- a/templates/template-angular/src/index.html
+++ b/templates/template-angular/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/templates/template-blazor/src/wwwroot/index.html
+++ b/templates/template-blazor/src/wwwroot/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/templates/template-leptos/index.html
+++ b/templates/template-leptos/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -7,4 +7,5 @@
     <link data-trunk rel="copy-dir" href="public" />
     <link data-trunk rel="rust" data-wasm-opt="z" />
   </head>
+  <body></body>
 </html>

--- a/templates/template-preact-ts/index.html
+++ b/templates/template-preact-ts/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-preact/index.html
+++ b/templates/template-preact/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-react-ts/index.html
+++ b/templates/template-react-ts/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-react/index.html
+++ b/templates/template-react/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-solid-ts/index.html
+++ b/templates/template-solid-ts/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/templates/template-solid/index.html
+++ b/templates/template-solid/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/templates/template-svelte-ts/index.html
+++ b/templates/template-svelte-ts/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-svelte/index.html
+++ b/templates/template-svelte/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-sycamore/index.html
+++ b/templates/template-sycamore/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -6,4 +6,5 @@
     <link data-trunk rel="css" href="styles.css" />
     <link data-trunk rel="copy-dir" href="public" />
   </head>
+  <body></body>
 </html>

--- a/templates/template-vanilla-ts/index.html
+++ b/templates/template-vanilla-ts/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-vanilla/src/index.html
+++ b/templates/template-vanilla/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-vue-ts/index.html
+++ b/templates/template-vue-ts/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-vue/index.html
+++ b/templates/template-vue/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/templates/template-yew/index.html
+++ b/templates/template-yew/index.html
@@ -6,6 +6,5 @@
     <link data-trunk rel="css" href="styles.css" />
     <link data-trunk rel="copy-dir" href="public" />
   </head>
-  <body>
-  </body>
+  <body></body>
 </html>

--- a/templates/template-yew/index.html
+++ b/templates/template-yew/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -6,5 +6,5 @@
     <link data-trunk rel="css" href="styles.css" />
     <link data-trunk rel="copy-dir" href="public" />
   </head>
-  <body></body>
+  <body></body>d
 </html>

--- a/templates/template-yew/index.html
+++ b/templates/template-yew/index.html
@@ -6,4 +6,6 @@
     <link data-trunk rel="css" href="styles.css" />
     <link data-trunk rel="copy-dir" href="public" />
   </head>
+  <body>
+  </body>
 </html>

--- a/worker/index.html
+++ b/worker/index.html
@@ -2,7 +2,7 @@
      SPDX-License-Identifier: Apache-2.0
      SPDX-License-Identifier: MIT -->
 
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION

The current template is missing the `body` element, causing errors:
![image](https://github.com/tauri-apps/create-tauri-app/assets/10093193/a6ccc3e3-0f65-4642-9665-54f95acb443c)

After run `trunk serve` it's shows what is wrong
```2024-05-10T19:24:35.416687Z ERROR ❌ error
error from build pipeline

Caused by:
    0: HTML build pipeline failed (1 errors), showing first
    1: failed to finalize asset pipeline
    2: Document has neither a <link data-trunk rel="rust"/> nor a <body>. Either one must be present.
```
