### PR TITLE
fix: remove redundant d in yew template

### DIFF
--- a/templates/template-yew/index.html
+++ b/templates/template-yew/index.html
@@ -7,5 +7,4 @@
     <link data-trunk rel="copy-dir" href="public" />
   </head>
   <body></body>
-  d
 </html>


### PR DESCRIPTION
This PR removes the unnecessary `d` character, which seems to have slipped in the yew template `index.html` in [this commit](https://github.com/stephlow/create-tauri-app/commit/7000c6ce2db33234169cc2b5f98264feb5e02351#diff-d523f918558d1d1d40885adc2038e25fbc0326b6ed548c9d5ce77bd5f6beafbeR9).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->
