### PR TITLE
chore: document why `_lib` suffix exists

### DIFF
--- a/templates/_base_/src-tauri/Cargo.toml.lte
+++ b/templates/_base_/src-tauri/Cargo.toml.lte
@@ -8,6 +8,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 {% if rc %}[lib]
+# The `_lib` suffix may seem redundant but it is necessary
+# to make the lib name unique and wouldn't conflict with the bin name.
+# This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
 name = "{% lib_name %}"
 crate-type = ["staticlib", "cdylib", "rlib"]
 


### PR DESCRIPTION
ref: https://github.com/rust-lang/cargo/issues/8519