### PR TITLE
fix: dioxus template needs tauri CLI

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -242,7 +242,7 @@ impl<'a> Template {
     pub const fn needs_tauri_cli(&self) -> bool {
         matches!(
             self,
-            Template::Sycamore | Template::Yew | Template::Leptos | Template::Vanilla
+            Template::Dioxus | Template::Sycamore | Template::Yew | Template::Leptos | Template::Vanilla
         )
     }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->


I tried the dioxus template locally and found that it does not warn you when the tauri CLI is missing.

