### PR TITLE
fix(template-dioxus): pass `--release` to `dx` in `beforeBuildCommand

### DIFF
--- a/.changes/dioxus-release.md
+++ b/.changes/dioxus-release.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Pass `--release` to `dx` CLI in `beforeBuildCommand` for `dioxus` template to generate smaller and optimized wasm bundle.

--- a/templates/template-dioxus/.manifest
+++ b/templates/template-dioxus/.manifest
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 beforeDevCommand = dx serve --port 1420
-beforeBuildCommand = dx build
+beforeBuildCommand = dx build --release
 devUrl = http://localhost:1420
 frontendDist = ../dist
 withGlobalTauri = true


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->

As title mentioned. The size of WASM dist is significantly decreased after running `dx build` with argument `--release`.

<img width="920" alt="image" src="https://github.com/user-attachments/assets/a376ef5a-5887-4759-876c-b31731d4f11f">

Before using `dx build --release`

<img width="920" alt="image" src="https://github.com/user-attachments/assets/28d85ece-2ad1-41c2-a41e-9aa32d4f9b71">

References: https://dioxuslabs.com/learn/0.4/CLI/cmd/build/

> You can use this command to build a project:
> ```
> dx build --release
> ```
