### PR TITLE
feat: update Svelte framework version to 5 in templates

### DIFF
--- a/.changes/svelte-5.md
+++ b/.changes/svelte-5.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Update `svelte` and `svelte-ts` templates to Svelte 5.

--- a/templates/template-svelte-ts/package.json.lte
+++ b/templates/template-svelte-ts/package.json.lte
@@ -17,14 +17,14 @@
     "@tauri-apps/plugin-shell": "^2"{% endif %}
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.1",
-    "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0",
-    "svelte": "^4.2.7",
-    "svelte-check": "^3.6.0",
-		"tslib": "^2.4.1",
-    "typescript": "^5.0.0",
-    "vite": "^5.0.3",
+    "@sveltejs/adapter-static": "^3.0.5",
+    "@sveltejs/kit": "^2.7.0",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
+    "tslib": "^2.8.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.10",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-svelte-ts/src/routes/+page.svelte.lte
+++ b/templates/template-svelte-ts/src/routes/+page.svelte.lte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/{% if v2 %}core{% else %}tauri{% endif %}";
 
-  let name = "";
-  let greetMsg = "";
+  let name = $state("");
+  let greetMsg = $state("");
 
-  async function greet() {
+  async function greet(event: Event) {
+    event.preventDefault();
     // Learn more about Tauri commands at {% if v2 %}https://tauri.app/develop/calling-rust/{% else %}https://v1.tauri.app/v1/guides/features/command{% endif %}
     greetMsg = await invoke("greet", { name });
   }
@@ -26,7 +27,7 @@
   </div>
   <p>Click on the Tauri, Vite, and SvelteKit logos to learn more.</p>
 
-  <form class="row" on:submit|preventDefault={greet}>
+  <form class="row" onsubmit={greet}>
     <input id="greet-input" placeholder="Enter a name..." bind:value={name} />
     <button type="submit">Greet</button>
   </form>

--- a/templates/template-svelte/package.json.lte
+++ b/templates/template-svelte/package.json.lte
@@ -17,13 +17,13 @@
     "@tauri-apps/plugin-shell": "^2"{% endif %}
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.1",
-    "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0",
-    "svelte": "^4.2.7",
-    "svelte-check": "^3.6.0",
-    "typescript": "^5.0.0",
-    "vite": "^5.0.3",
+    "@sveltejs/adapter-static": "^3.0.5",
+    "@sveltejs/kit": "^2.7.0",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.10",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-svelte/src/routes/+page.svelte.lte
+++ b/templates/template-svelte/src/routes/+page.svelte.lte
@@ -1,10 +1,11 @@
 <script>
   import { invoke } from "@tauri-apps/api/{% if v2 %}core{% else %}tauri{% endif %}";
 
-  let name = "";
-  let greetMsg = "";
+  let name = $state("");
+  let greetMsg = $state("");
 
-  async function greet() {
+  async function greet(event) {
+    event.preventDefault();
     // Learn more about Tauri commands at {% if v2 %}https://tauri.app/develop/calling-rust/{% else %}https://v1.tauri.app/v1/guides/features/command{% endif %}
     greetMsg = await invoke("greet", { name });
   }
@@ -26,7 +27,7 @@
   </div>
   <p>Click on the Tauri, Vite, and SvelteKit logos to learn more.</p>
 
-  <form class="row" on:submit|preventDefault={greet}>
+  <form class="row" onsubmit={greet}>
     <input id="greet-input" placeholder="Enter a name..." bind:value={name} />
     <button type="submit">Greet</button>
   </form>


### PR DESCRIPTION
Svelte 5 has been [officially released](https://svelte.dev/blog/svelte-5-is-alive) recently. The `svelte` and `svelte-ts` templates have been updated to this new version, allowing developers to utilize the improved features of Svelte 5.