### PR TITLE
fix: fix false warning about deno and bun missing #830

### DIFF
--- a/.changes/bug_deno-bun_missing.md
+++ b/.changes/bug_deno-bun_missing.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+Fix: Removed false warning about missing dependencies deno and bun.

--- a/.changes/bug_deno-bun_missing.md
+++ b/.changes/bug_deno-bun_missing.md
@@ -2,4 +2,4 @@
 "create-tauri-app": patch
 "create-tauri-app-js": patch
 ---
-Fix: Removed false warning about missing dependencies deno and bun.
+Fixed false warning about missing dependencies, Deno and Bun.

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -204,13 +204,13 @@ pub fn print_missing_deps(
             name: "Deno",
             instruction: format!("Visit {BLUE}{BOLD}https://deno.land/{RESET}"),
             exists: &|| is_cli_installed("deno", "-v"),
-            skip: pkg_manager == PackageManager::Deno,
+            skip: pkg_manager != PackageManager::Deno,
         },
         Dep {
             name: "Bun",
             instruction: format!("Visit {BLUE}{BOLD}https://bun.sh/{RESET}"),
             exists: &|| is_cli_installed("bun", "-v"),
-            skip: pkg_manager == PackageManager::Bun,
+            skip: pkg_manager != PackageManager::Bun,
         },
         #[cfg(windows)]
         Dep {


### PR DESCRIPTION
Set `skip` to true in case Deno or Bun is the package manager. The existence of the package will be checked separately, and a notice for missing dependencies will still be provided when Cargo is used to create a project with Deno or Bun as the package manager.

