### PR TITLE
style: fix Vite, SvelteKit and React branding

### DIFF
--- a/templates/template-preact-ts/src/App.tsx.lte
+++ b/templates/template-preact-ts/src/App.tsx.lte
@@ -17,7 +17,7 @@ function App() {
       <h1>Welcome to Tauri + Preact</h1>
 
       <div class="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" class="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">

--- a/templates/template-preact-ts/vite.config.ts.lte
+++ b/templates/template-preact-ts/vite.config.ts.lte
@@ -4,13 +4,13 @@ import preact from "@preact/preset-vite";{% if v2 %}
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [preact()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -25,7 +25,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-preact/src/App.jsx.lte
+++ b/templates/template-preact/src/App.jsx.lte
@@ -17,7 +17,7 @@ function App() {
       <h1>Welcome to Tauri + Preact</h1>
 
       <div class="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" class="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">

--- a/templates/template-preact/vite.config.js.lte
+++ b/templates/template-preact/vite.config.js.lte
@@ -3,13 +3,13 @@ import preact from "@preact/preset-vite";{% if v2 %}
 
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [preact()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -24,7 +24,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-react-ts/src/App.tsx.lte
+++ b/templates/template-react-ts/src/App.tsx.lte
@@ -17,13 +17,13 @@ function App() {
       <h1>Welcome to Tauri + React</h1>
 
       <div className="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" className="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">
           <img src="/tauri.svg" className="logo tauri" alt="Tauri logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://react.dev" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>

--- a/templates/template-react-ts/vite.config.ts.lte
+++ b/templates/template-react-ts/vite.config.ts.lte
@@ -4,13 +4,13 @@ import react from "@vitejs/plugin-react";{% if v2 %}
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -25,7 +25,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-react/src/App.jsx.lte
+++ b/templates/template-react/src/App.jsx.lte
@@ -17,13 +17,13 @@ function App() {
       <h1>Welcome to Tauri + React</h1>
 
       <div className="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" className="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">
           <img src="/tauri.svg" className="logo tauri" alt="Tauri logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://react.dev" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>

--- a/templates/template-react/vite.config.js.lte
+++ b/templates/template-react/vite.config.js.lte
@@ -3,13 +3,13 @@ import react from "@vitejs/plugin-react";{% if v2 %}
 
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -24,7 +24,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-solid-ts/src/App.tsx.lte
+++ b/templates/template-solid-ts/src/App.tsx.lte
@@ -17,7 +17,7 @@ function App() {
       <h1>Welcome to Tauri + Solid</h1>
 
       <div class="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" class="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">

--- a/templates/template-solid-ts/vite.config.ts.lte
+++ b/templates/template-solid-ts/vite.config.ts.lte
@@ -4,13 +4,13 @@ import solid from "vite-plugin-solid";{% if v2 %}
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [solid()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -25,7 +25,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-solid/src/App.jsx.lte
+++ b/templates/template-solid/src/App.jsx.lte
@@ -17,7 +17,7 @@ function App() {
       <h1>Welcome to Tauri + Solid</h1>
 
       <div class="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" class="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">

--- a/templates/template-solid/vite.config.js.lte
+++ b/templates/template-solid/vite.config.js.lte
@@ -3,13 +3,13 @@ import solid from "vite-plugin-solid";{% if v2 %}
 
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [solid()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -24,7 +24,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-svelte-ts/src/routes/+page.svelte.lte
+++ b/templates/template-svelte-ts/src/routes/+page.svelte.lte
@@ -15,13 +15,13 @@
   <h1>Welcome to Tauri + Svelte</h1>
 
   <div class="row">
-    <a href="https://vitejs.dev" target="_blank">
+    <a href="https://vite.dev" target="_blank">
       <img src="/vite.svg" class="logo vite" alt="Vite Logo" />
     </a>
     <a href="https://tauri.app" target="_blank">
       <img src="/tauri.svg" class="logo tauri" alt="Tauri Logo" />
     </a>
-    <a href="https://kit.svelte.dev" target="_blank">
+    <a href="https://svelte.dev" target="_blank">
       <img src="/svelte.svg" class="logo svelte-kit" alt="SvelteKit Logo" />
     </a>
   </div>

--- a/templates/template-svelte-ts/tsconfig.json
+++ b/templates/template-svelte-ts/tsconfig.json
@@ -11,8 +11,8 @@
     "strict": true,
     "moduleResolution": "bundler"
   }
-  // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-  // except $lib which is handled by https://kit.svelte.dev/docs/configuration#files
+  // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
+  // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
   //
   // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
   // from the referenced tsconfig.json - TypeScript does not merge them in

--- a/templates/template-svelte-ts/vite.config.js.lte
+++ b/templates/template-svelte-ts/vite.config.js.lte
@@ -4,13 +4,13 @@ import { sveltekit } from "@sveltejs/kit/vite";{% if v2 %}
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [sveltekit()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -25,7 +25,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-svelte/jsconfig.json
+++ b/templates/template-svelte/jsconfig.json
@@ -11,8 +11,8 @@
     "strict": true,
     "moduleResolution": "bundler"
   }
-  // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-  // except $lib which is handled by https://kit.svelte.dev/docs/configuration#files
+  // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
+  // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
   //
   // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
   // from the referenced tsconfig.json - TypeScript does not merge them in

--- a/templates/template-svelte/src/routes/+page.svelte.lte
+++ b/templates/template-svelte/src/routes/+page.svelte.lte
@@ -15,13 +15,13 @@
   <h1>Welcome to Tauri + Svelte</h1>
 
   <div class="row">
-    <a href="https://vitejs.dev" target="_blank">
+    <a href="https://vite.dev" target="_blank">
       <img src="/vite.svg" class="logo vite" alt="Vite Logo" />
     </a>
     <a href="https://tauri.app" target="_blank">
       <img src="/tauri.svg" class="logo tauri" alt="Tauri Logo" />
     </a>
-    <a href="https://kit.svelte.dev" target="_blank">
+    <a href="https://svelte.dev" target="_blank">
       <img src="/svelte.svg" class="logo svelte-kit" alt="SvelteKit Logo" />
     </a>
   </div>

--- a/templates/template-svelte/vite.config.js.lte
+++ b/templates/template-svelte/vite.config.js.lte
@@ -4,13 +4,13 @@ import { sveltekit } from "@sveltejs/kit/vite";{% if v2 %}
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [sveltekit()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -25,7 +25,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-vanilla-ts/index.html
+++ b/templates/template-vanilla-ts/index.html
@@ -13,7 +13,7 @@
       <h1>Welcome to Tauri</h1>
 
       <div class="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/src/assets/vite.svg" class="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">

--- a/templates/template-vanilla-ts/vite.config.ts.lte
+++ b/templates/template-vanilla-ts/vite.config.ts.lte
@@ -3,12 +3,12 @@ import { defineConfig } from "vite";{% if v2 %}
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -23,7 +23,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-vue-ts/src/App.vue.lte
+++ b/templates/template-vue-ts/src/App.vue.lte
@@ -16,7 +16,7 @@ async function greet() {
     <h1>Welcome to Tauri + Vue</h1>
 
     <div class="row">
-      <a href="https://vitejs.dev" target="_blank">
+      <a href="https://vite.dev" target="_blank">
         <img src="/vite.svg" class="logo vite" alt="Vite logo" />
       </a>
       <a href="https://tauri.app" target="_blank">

--- a/templates/template-vue-ts/vite.config.ts.lte
+++ b/templates/template-vue-ts/vite.config.ts.lte
@@ -4,13 +4,13 @@ import vue from "@vitejs/plugin-vue";{% if v2 %}
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [vue()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -25,7 +25,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },

--- a/templates/template-vue/src/App.vue.lte
+++ b/templates/template-vue/src/App.vue.lte
@@ -16,7 +16,7 @@ async function greet() {
     <h1>Welcome to Tauri + Vue</h1>
 
     <div class="row">
-      <a href="https://vitejs.dev" target="_blank">
+      <a href="https://vite.dev" target="_blank">
         <img src="/vite.svg" class="logo vite" alt="Vite logo" />
       </a>
       <a href="https://tauri.app" target="_blank">

--- a/templates/template-vue/vite.config.js.lte
+++ b/templates/template-vue/vite.config.js.lte
@@ -3,13 +3,13 @@ import vue from "@vitejs/plugin-vue";{% if v2 %}
 
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [vue()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
-  // 1. prevent vite from obscuring rust errors
+  // 1. prevent Vite from obscuring rust errors
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
@@ -24,7 +24,7 @@ export default defineConfig(async () => ({
         }
       : undefined,{% endif %}
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
+      // 3. tell Vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
   },


### PR DESCRIPTION
This pull request addresses updates to the official URLs for Vite, SvelteKit and React. The URLs have been changed from `https://vitejs.dev`, `https://kit.svelte.dev` and `https://reactjs.org` to `https://vite.dev`, `https://svelte.dev` and `https://react.dev`, respectively, as the former URLs now redirect to the new addresses.

You can find out more about merging Svelte and SvelteKit URLs into one [here](https://svelte.dev/blog/the-omnisite).

Additionally, this PR includes corrections to the capitalization of "Vite" in instances where it appears within sentences, ensuring proper styling guidelines.