### PR TITLE
refactor(templates/svelte): put site in SPA mode by default

### DIFF
--- a/.changes/svelte-spa.md
+++ b/.changes/svelte-spa.md
@@ -1,0 +1,7 @@
+---
+"create-tauri-app": "patch"
+"create-tauri-app-js": "patch"
+---
+
+Changed Svelte templates to use `@sveltejs/adapter-static`'s fallback feature instead of disabling SSR per-router, See https://svelte.dev/docs/kit/single-page-apps
+

--- a/templates/template-svelte-ts/src/routes/+layout.ts
+++ b/templates/template-svelte-ts/src/routes/+layout.ts
@@ -1,5 +1,5 @@
 // Tauri doesn't have a Node.js server to do proper SSR
-// so we will use adapter-static to prerender the app (SSG)
+// so we use adapter-static with a fallback to index.html to put the site in SPA mode
+// See: https://svelte.dev/docs/kit/single-page-apps
 // See: https://v2.tauri.app/start/frontend/sveltekit/ for more info
-export const prerender = true;
 export const ssr = false;

--- a/templates/template-svelte-ts/svelte.config.js
+++ b/templates/template-svelte-ts/svelte.config.js
@@ -1,5 +1,6 @@
 // Tauri doesn't have a Node.js server to do proper SSR
-// so we will use adapter-static to prerender the app (SSG)
+// so we use adapter-static with a fallback to index.html to put the site in SPA mode
+// See: https://svelte.dev/docs/kit/single-page-apps
 // See: https://v2.tauri.app/start/frontend/sveltekit/ for more info
 import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
@@ -8,7 +9,9 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 const config = {
   preprocess: vitePreprocess(),
   kit: {
-    adapter: adapter(),
+    adapter: adapter({
+      fallback: "index.html",
+    }),
   },
 };
 

--- a/templates/template-svelte/src/routes/+layout.js
+++ b/templates/template-svelte/src/routes/+layout.js
@@ -1,5 +1,5 @@
 // Tauri doesn't have a Node.js server to do proper SSR
-// so we will use adapter-static to prerender the app (SSG)
+// so we use adapter-static with a fallback to index.html to put the site in SPA mode
+// See: https://svelte.dev/docs/kit/single-page-apps
 // See: https://v2.tauri.app/start/frontend/sveltekit/ for more info
-export const prerender = true;
 export const ssr = false;

--- a/templates/template-svelte/svelte.config.js
+++ b/templates/template-svelte/svelte.config.js
@@ -1,12 +1,15 @@
 // Tauri doesn't have a Node.js server to do proper SSR
-// so we will use adapter-static to prerender the app (SSG)
+// so we use adapter-static with a fallback to index.html to put the site in SPA mode
+// See: https://svelte.dev/docs/kit/single-page-apps
 // See: https://v2.tauri.app/start/frontend/sveltekit/ for more info
 import adapter from "@sveltejs/adapter-static";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
-    adapter: adapter(),
+    adapter: adapter({
+      fallback: "index.html",
+    }),
   },
 };
 


### PR DESCRIPTION
Putting the site into SPA mode by default makes SvelteKit's `load` functions behave more intuitively.
