### PR TITLE
Remove section in README (templates/template-vue-ts)

### DIFF
--- a/templates/template-vue-ts/README.md
+++ b/templates/template-vue-ts/README.md
@@ -5,12 +5,3 @@ This template should help get you started developing with Vue 3 and TypeScript i
 ## Recommended IDE Setup
 
 - [VS Code](https://code.visualstudio.com/) + [Vue - Official](https://marketplace.visualstudio.com/items?itemName=Vue.volar) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
-
-## Type Support For `.vue` Imports in TS
-
-Since TypeScript cannot handle type information for `.vue` imports, they are shimmed to be a generic Vue component type by default. In most cases this is fine if you don't really care about component prop types outside of templates. However, if you wish to get actual prop types in `.vue` imports (for example to get props validation when using manual `h(...)` calls), you can enable Volar's Take Over mode by following these steps:
-
-1. Run `Extensions: Show Built-in Extensions` from VS Code's command palette, look for `TypeScript and JavaScript Language Features`, then right click and select `Disable (Workspace)`. By default, Take Over mode will enable itself if the default TypeScript extension is disabled.
-2. Reload the VS Code window by running `Developer: Reload Window` from the command palette.
-
-You can learn more about Take Over mode [here](https://github.com/johnsoncodehk/volar/discussions/471).


### PR DESCRIPTION
### What does this PR do?

- Removes section "Type Support For `.vue` Imports in TS" from README

#### Any background context you want to provide?

When I followed the instructions in the section, the IDE, VS Code, triggered the notification below.

> Takeover mode is no longer needed since v2 of Vue - Official extension.

![Takeover notification VS Code](https://github.com/user-attachments/assets/98a52439-dd2f-49f9-a737-acdd7c6abdd6)

#### More context

1. This is captured in the release notes for tag 2.0.0 [here](https://github.com/vuejs/language-tools/releases/tag/v2.0.0)
2. Takeover mode is no longer available on Vue.js docs

![Takeover search on Vue.js docs](https://github.com/user-attachments/assets/1ab1e51b-8ca0-4a6e-aa21-60b68663c366)
