### PR TITLE
fix: remove `.app` ending from default identifier

### DIFF
--- a/.changes/no-dot-app-in-default-id.md
+++ b/.changes/no-dot-app-in-default-id.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": "minor"
+"create-tauri-app-js": "minor"
+---
+
+Changed default app identifier from `com.{package_name}.app` to `com.{user_name}.{package_name}` as `.app` causes problems on macOS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "dialoguer",
  "pico-args",
  "rust-embed",
+ "whoami",
 ]
 
 [[package]]
@@ -468,6 +469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +702,22 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "whoami"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ rust-embed = { version = "8.3", features = [
     "compression",
     "interpolate-folder-path",
 ] }
+whoami = { version = "1.6.0", default-features = false }

--- a/src/category.rs
+++ b/src/category.rs
@@ -12,8 +12,8 @@ pub enum Category {
     Dotnet,
 }
 
-impl<'a> Category {
-    pub const ALL: &'a [Self] = &[Category::JsTs, Category::Rust, Category::Dotnet];
+impl Category {
+    pub const ALL: &[Self] = &[Category::JsTs, Category::Rust, Category::Dotnet];
 
     pub const fn package_managers(&self) -> &[PackageManager] {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,8 @@ where
     let identifier = match identifier {
         Some(name) => name,
         None => {
-            let default = format!("com.{package_name}.app");
+            let valid_user_name = utils::to_valid_pkg_name(&whoami::username());
+            let default = format!("com.{valid_user_name}.{package_name}");
             if skip {
                 default
             } else {

--- a/src/template.rs
+++ b/src/template.rs
@@ -143,8 +143,8 @@ impl Template {
     }
 }
 
-impl<'a> Template {
-    pub const ALL: &'a [Template] = &[
+impl Template {
+    pub const ALL: &[Template] = &[
         Template::Vanilla,
         Template::VanillaTs,
         Template::Vue,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->

Reference: https://github.com/tauri-apps/tauri/pull/13618#issuecomment-2977175651

Changed default app identifier from `com.{package_name}.app` to `com.{user_name}.{package_name}` as `.app` causes problems on macOS

(pulled in an extremely light weight crate `whoami` that increased the binary size by ~3KB)