### PR TITLE
Upgrade to Rust 2024 edition + bump MSRV

### DIFF
--- a/.changes/edition-2024.md
+++ b/.changes/edition-2024.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+Upgrade CLI and templates to Rust 2024 edition.

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [1.71, stable]
+        toolchain: [1.85, stable]
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ name = "create-tauri-app"
 description = "Rapidly scaffold out a new tauri app project."
 authors = ["Tauri Programme within The Commons Conservancy"]
 version = "4.6.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 repository = "https://github.com/tauri-apps/create-tauri-app"
 keywords = ["tauri"]
 categories = ["gui"]
 exclude = ["node", "worker", ".github", ".changes", ".scripts"]
-rust-version = "1.71"
+rust-version = "1.85"
 
 [[bin]]
 name = "cargo-create-tauri-app"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "create-tauri-app-node"
 version = "0.0.0"
 license = "Apache-2.0 OR MIT"

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -151,27 +151,37 @@ pub fn print_missing_deps(
     let deps: &[Dep<'_>] = &[
         Dep {
             name: "Rust",
-            instruction: format!("Visit {BLUE}{BOLD}https://www.rust-lang.org/learn/get-started#installing-rust{RESET}"),
+            instruction: format!(
+                "Visit {BLUE}{BOLD}https://www.rust-lang.org/learn/get-started#installing-rust{RESET}"
+            ),
             exists: &|| rustc_installed && cargo_installed,
             skip: rustc_installed || cargo_installed,
         },
-        Dep  {
+        Dep {
             name: "rustc",
-            instruction: format!("Visit {BLUE}{BOLD}https://www.rust-lang.org/learn/get-started#installing-rust{RESET} to install Rust"),
+            instruction: format!(
+                "Visit {BLUE}{BOLD}https://www.rust-lang.org/learn/get-started#installing-rust{RESET} to install Rust"
+            ),
             exists: &|| rustc_installed,
             skip: !rustc_installed && !cargo_installed,
         },
         Dep {
             name: "Cargo",
-            instruction: format!("Visit {BLUE}{BOLD}https://www.rust-lang.org/learn/get-started#installing-rust{RESET} to install Rust"),
+            instruction: format!(
+                "Visit {BLUE}{BOLD}https://www.rust-lang.org/learn/get-started#installing-rust{RESET} to install Rust"
+            ),
             exists: &|| cargo_installed,
             skip: !rustc_installed && !cargo_installed,
         },
         Dep {
             name: "Tauri CLI",
             instruction: match tauri_version {
-                TauriVersion::V1 => format!("Run `{BLUE}{BOLD}cargo install tauri-cli --version '^1.0.0' --locked{RESET}`"),
-                TauriVersion::V2 => format!("Run `{BLUE}{BOLD}cargo install tauri-cli --version '^2.0.0' --locked{RESET}`"),
+                TauriVersion::V1 => format!(
+                    "Run `{BLUE}{BOLD}cargo install tauri-cli --version '^1.0.0' --locked{RESET}`"
+                ),
+                TauriVersion::V2 => format!(
+                    "Run `{BLUE}{BOLD}cargo install tauri-cli --version '^2.0.0' --locked{RESET}`"
+                ),
             },
             exists: &|| is_tauri_cli_installed(tauri_version),
             skip: pkg_manager.is_node() || !template.needs_tauri_cli(),
@@ -190,7 +200,9 @@ pub fn print_missing_deps(
         },
         Dep {
             name: "wasm32 target",
-            instruction: format!("Run `{BLUE}{BOLD}rustup target add wasm32-unknown-unknown{RESET}`"),
+            instruction: format!(
+                "Run `{BLUE}{BOLD}rustup target add wasm32-unknown-unknown{RESET}`"
+            ),
             exists: &is_wasm32_installed,
             skip: pkg_manager.is_node() || !template.needs_wasm32_target(),
         },
@@ -215,7 +227,9 @@ pub fn print_missing_deps(
         #[cfg(windows)]
         Dep {
             name: "Webview2",
-            instruction: format!("Visit {BLUE}{BOLD}https://go.microsoft.com/fwlink/p/?LinkId=2124703{RESET}"),
+            instruction: format!(
+                "Visit {BLUE}{BOLD}https://go.microsoft.com/fwlink/p/?LinkId=2124703{RESET}"
+            ),
             exists: &is_webview2_installed,
             skip: false,
         },
@@ -228,10 +242,14 @@ pub fn print_missing_deps(
         ))]
         Dep {
             name: "webkit2gtk & rsvg2",
-            instruction: format!("Visit {BLUE}{BOLD}{}{RESET}", match tauri_version {
-                TauriVersion::V1 => "https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux",
-                TauriVersion::V2 => "https://tauri.app/guides/prerequisites/#linux",
-            }),
+            instruction: format!(
+                "Visit {BLUE}{BOLD}{}{RESET}",
+                match tauri_version {
+                    TauriVersion::V1 =>
+                        "https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux",
+                    TauriVersion::V2 => "https://tauri.app/guides/prerequisites/#linux",
+                }
+            ),
             exists: &|| webkit2gtk_installed && rsvg2_installed,
             skip: webkit2gtk_installed || rsvg2_installed,
         },
@@ -244,10 +262,14 @@ pub fn print_missing_deps(
         ))]
         Dep {
             name: "webkit2gtk",
-            instruction: format!("Visit {BLUE}{BOLD}{}{RESET}", match tauri_version {
-                TauriVersion::V1 => "https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux",
-                TauriVersion::V2 => "https://tauri.app/guides/prerequisites/#linux",
-            }),
+            instruction: format!(
+                "Visit {BLUE}{BOLD}{}{RESET}",
+                match tauri_version {
+                    TauriVersion::V1 =>
+                        "https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux",
+                    TauriVersion::V2 => "https://tauri.app/guides/prerequisites/#linux",
+                }
+            ),
             exists: &|| webkit2gtk_installed,
             skip: !rsvg2_installed && !webkit2gtk_installed,
         },
@@ -260,10 +282,14 @@ pub fn print_missing_deps(
         ))]
         Dep {
             name: "rsvg2",
-            instruction: format!("Visit {BLUE}{BOLD}{}{RESET}", match tauri_version {
-                TauriVersion::V1 => "https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux",
-                TauriVersion::V2 => "https://tauri.app/guides/prerequisites/#linux",
-            }),
+            instruction: format!(
+                "Visit {BLUE}{BOLD}{}{RESET}",
+                match tauri_version {
+                    TauriVersion::V1 =>
+                        "https://v1.tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux",
+                    TauriVersion::V2 => "https://tauri.app/guides/prerequisites/#linux",
+                }
+            ),
             exists: &|| rsvg2_installed,
             skip: !rsvg2_installed && !webkit2gtk_installed,
         },
@@ -279,7 +305,7 @@ pub fn print_missing_deps(
             instruction: format!("Visit {BLUE}{BOLD}https://dotnet.microsoft.com/download{RESET}"),
             exists: &|| is_cli_installed("dotnet", "--info"),
             skip: !template.needs_dotnet() || pkg_manager.is_node(),
-        }
+        },
     ];
 
     let missing_deps: Vec<(&str, &str)> = deps
@@ -306,7 +332,9 @@ pub fn print_missing_deps(
             });
 
     if !missing_deps.is_empty() {
-        println!("\n\nYour system is {YELLOW}missing dependencies{RESET} (or they do not exist in {YELLOW}$PATH{RESET}):");
+        println!(
+            "\n\nYour system is {YELLOW}missing dependencies{RESET} (or they do not exist in {YELLOW}$PATH{RESET}):"
+        );
         for (index, (name, instruction)) in missing_deps.iter().enumerate() {
             if index == 0 {
                 println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,9 +293,18 @@ where
     // is valid, otherwise, we error and exit
     if !pkg_manager.templates().contains(&template) {
         eprintln!(
-            "{BOLD}{RED}error{RESET}: the {GREEN}{template}{RESET} template is not suppported for the {GREEN}{pkg_manager}{RESET} package manager\n       possible templates for {GREEN}{pkg_manager}{RESET} are: [{}]\n       or maybe you meant to use another package manager\n       possible package managers for {GREEN}{template}{RESET} are: [{}]" ,
-            templates_no_flavors.iter().map(|e|format!("{GREEN}{e}{RESET}")).collect::<Vec<_>>().join(", "),
-            template.possible_package_managers().iter().map(|e|format!("{GREEN}{e}{RESET}")).collect::<Vec<_>>().join(", "),
+            "{BOLD}{RED}error{RESET}: the {GREEN}{template}{RESET} template is not suppported for the {GREEN}{pkg_manager}{RESET} package manager\n       possible templates for {GREEN}{pkg_manager}{RESET} are: [{}]\n       or maybe you meant to use another package manager\n       possible package managers for {GREEN}{template}{RESET} are: [{}]",
+            templates_no_flavors
+                .iter()
+                .map(|e| format!("{GREEN}{e}{RESET}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+            template
+                .possible_package_managers()
+                .iter()
+                .map(|e| format!("{GREEN}{e}{RESET}"))
+                .collect::<Vec<_>>()
+                .join(", "),
         );
         exit(1);
     }
@@ -343,7 +352,9 @@ where
             TauriVersion::V2 => "https://tauri.app/start/prerequisites/",
         };
 
-        println!("Make sure you have installed the prerequisites for your OS: {BLUE}{BOLD}{prereqs_url}{RESET}, then run:");
+        println!(
+            "Make sure you have installed the prerequisites for your OS: {BLUE}{BOLD}{prereqs_url}{RESET}, then run:"
+        );
     } else {
         println!(" To get started run:")
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 
 #[derive(Default, Clone, PartialEq, Eq, Debug)]
 pub struct Manifest<'a> {

--- a/src/utils/dialoguer_theme.rs
+++ b/src/utils/dialoguer_theme.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use dialoguer::{
-    console::{style, Style, StyledObject},
+    console::{Style, StyledObject, style},
     theme::Theme,
 };
 

--- a/src/utils/lte.rs
+++ b/src/utils/lte.rs
@@ -212,7 +212,7 @@ enum Stmt<'a> {
     },
 }
 
-impl<'a> Stmt<'a> {
+impl Stmt<'_> {
     fn execute<V, T>(&self, out: &mut T, data: &HashMap<&str, V>) -> Result<()>
     where
         T: Write,

--- a/templates/_base_/src-tauri/Cargo.toml.lte
+++ b/templates/_base_/src-tauri/Cargo.toml.lte
@@ -3,7 +3,7 @@ name = "{% package_name %}"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/templates/template-dioxus/Cargo.toml.lte
+++ b/templates/template-dioxus/Cargo.toml.lte
@@ -1,7 +1,7 @@
 [package]
 name = "{% package_name %}-ui"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/templates/template-leptos/Cargo.toml.lte
+++ b/templates/template-leptos/Cargo.toml.lte
@@ -1,7 +1,7 @@
 [package]
 name = "{% package_name %}-ui"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/templates/template-sycamore/Cargo.toml.lte
+++ b/templates/template-sycamore/Cargo.toml.lte
@@ -1,7 +1,7 @@
 [package]
 name = "{% package_name %}-ui"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/templates/template-yew/Cargo.toml.lte
+++ b/templates/template-yew/Cargo.toml.lte
@@ -1,7 +1,7 @@
 [package]
 name = "{% package_name %}-ui"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]


### PR DESCRIPTION
When I use Create Tauri App this is always the first thing I change so thought it might be worth PRing back to the main project.

This does result in an MSRV bump but realistically I don't think many people are creating new projects on an old Rust version.