### PR TITLE
fix(dioxus): fix template-dioxus loading assets error

### DIFF
--- a/.changes/change.md
+++ b/.changes/change.md
@@ -1,5 +1,6 @@
 ---
 "create-tauri-app": patch
+"create-tauri-app-js": patch
 ---
 
 fix template-dioxus loading assets error

--- a/.changes/change.md
+++ b/.changes/change.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+fix template-dioxus loading assets error

--- a/templates/template-dioxus/src/app.rs.lte
+++ b/templates/template-dioxus/src/app.rs.lte
@@ -4,6 +4,10 @@ use dioxus::prelude::*;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
+static CSS: Asset = asset!("/assets/styles.css");
+static TAURI_ICON: Asset = asset!("/assets/tauri.svg");
+static DIOXUS_ICON: Asset = asset!("/assets/dioxus.png");
+
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "{% if v2 %}core{% else %}tauri{% endif %}"])]
@@ -32,7 +36,7 @@ pub fn App() -> Element {
     };
 
     rsx! {
-        link { rel: "stylesheet", href: "styles.css" }
+        link { rel: "stylesheet", href: CSS }
         main {
             class: "container",
             h1 { "Welcome to Tauri + Dioxus" }
@@ -43,7 +47,7 @@ pub fn App() -> Element {
                     href: "https://tauri.app",
                     target: "_blank",
                     img {
-                        src: "/tauri.svg",
+                        src: TAURI_ICON,
                         class: "logo tauri",
                          alt: "Tauri logo"
                     }
@@ -52,7 +56,7 @@ pub fn App() -> Element {
                     href: "https://dioxuslabs.com/",
                     target: "_blank",
                     img {
-                        src: "/dioxus.png",
+                        src: DIOXUS_ICON,
                         class: "logo dioxus",
                         alt: "Dioxus logo"
                     }


### PR DESCRIPTION
fix issue: [bug] Assets not loading correctly in Dioxus frontend template #908


<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->
