### PR TITLE
chore(sycamore-template): update sycamore template link

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -131,7 +131,7 @@ impl Template {
             Template::Solid => "Solid - (https://solidjs.com/)",
             Template::Yew => "Yew - (https://yew.rs/)",
             Template::Leptos => "Leptos - (https://leptos.dev/)",
-            Template::Sycamore => "Sycamore - (https://sycamore-rs.netlify.app/)",
+            Template::Sycamore => "Sycamore - (https://sycamore.dev/)",
             Template::Angular => "Angular - (https://angular.dev/)",
             Template::Preact => "Preact - (https://preactjs.com/)",
             Template::Blazor => {


### PR DESCRIPTION
Very simple; the template selection dialog had an old link for Sycamore documentation. The link works fine, it just redirects, and I assume it should be updated.

The link is already used and was replaced in #839 right [here](https://github.com/tauri-apps/create-tauri-app/pull/839/commits/378cdc6b3677b019cec26743f028f0c591f15b6e#diff-638d07412e61e2d4138030a47df4e870de808247e8e9eea380b1ab20fc341363L43-R46), it just wasn't updated in `src/template.rs` to match.

The current behavior:

<img width="656" height="192" alt="image" src="https://github.com/user-attachments/assets/4a77fc7f-6fb4-46a8-b421-a2d3418aa56e" />

With my pull request:

<img width="655" height="186" alt="image" src="https://github.com/user-attachments/assets/95491b63-8d57-4967-83c8-a2811b86bdbe" />
