### PR TITLE
remove token for oidc token publishing

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -4,6 +4,10 @@
 
 name: publish napi modules
 
+permissions:
+  # required for OIDC token
+  id-token: write
+
 env:
   DEBUG: napi:*
   APP_NAME: create-tauri-app
@@ -210,7 +214,7 @@ jobs:
           npm i -g --force corepack
           corepack enable
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -236,12 +240,9 @@ jobs:
 
       - name: Publish
         run: |
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-          npm publish
           jq '.name = "create-tauri" | .bin = { "create-tauri": .bin["create-tauri-app"] } |  del(.scripts.prepublishOnly)' package.json > package.tmp
           mv -f package.tmp package.json
           npm publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ORG_NPM_TOKEN }}
           RELEASE_ID: ${{ github.event.client_payload.releaseId || inputs.releaseId }}

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -238,8 +238,10 @@ jobs:
         run: ls -R ./npm
         shell: bash
 
+      # We publish as `create-tauri-app` first and then rewrite the package.json to publish as `create-tauri` as well.
       - name: Publish
         run: |
+          npm publish
           jq '.name = "create-tauri" | .bin = { "create-tauri": .bin["create-tauri-app"] } |  del(.scripts.prepublishOnly)' package.json > package.tmp
           mv -f package.tmp package.json
           npm publish


### PR DESCRIPTION
## Motivation

We have enabled trusted publishing. With this, we need to give it perms to create the token and then remove setting it.
