### PR TITLE
Fixes #935 and cleans up build process: reroutes to `builds` dir, adds gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 
 /node_modules
 /target
+/builds
+/**/src/obj/
 /package-json.lock
 /yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /**/src/obj/
 /package-json.lock
 /yarn.lock
+**.sln

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ where
         }
     };
 
-    let target_dir = cwd.join(&project_name);
+    let target_dir = cwd.join("builds").join(&project_name);
 
     // Package name used in Cargo.toml, Package.json ...etc
     let package_name = if utils::is_valid_pkg_name(&project_name) {
@@ -347,13 +347,23 @@ where
     } else {
         println!(" To get started run:")
     }
+    // Display the path to the created project relative to the current working directory.
+    let display_dir = if target_dir != cwd {
+        match target_dir.strip_prefix(&cwd) {
+            Ok(p) => p.to_string_lossy().to_string(),
+            Err(_) => project_name.clone(),
+        }
+    } else {
+        String::new()
+    };
+
     if target_dir != cwd {
         println!(
             "  cd {}",
-            if project_name.contains(' ') {
-                format!("\"{project_name}\"")
+            if display_dir.contains(' ') {
+                format!("\"{display_dir}\"")
             } else {
-                project_name
+                display_dir
             }
         );
     }

--- a/templates/_base_/src-tauri/Cargo.toml.lte
+++ b/templates/_base_/src-tauri/Cargo.toml.lte
@@ -19,11 +19,11 @@ tauri-build = { version = "1", features = [] }
 
 [dependencies]
 tauri = { version = "1", features = ["shell-open"] }{% else %}[build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "^2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
-tauri-plugin-opener = "2"{% endif %}
+tauri = { version = "^2", features = [] }
+tauri-plugin-opener = "^2"{% endif %}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 {% if v1 %}

--- a/templates/template-angular/tsconfig.json
+++ b/templates/template-angular/tsconfig.json
@@ -13,7 +13,8 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "forceConsistentCasingInFileNames": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/templates/template-preact-ts/tsconfig.json
+++ b/templates/template-preact-ts/tsconfig.json
@@ -14,6 +14,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
+    "forceConsistentCasingInFileNames": true,
 
     /* Linting */
     "strict": true,

--- a/templates/template-react-ts/tsconfig.json
+++ b/templates/template-react-ts/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "forceConsistentCasingInFileNames": true,
 
     /* Linting */
     "strict": true,

--- a/templates/template-solid-ts/tsconfig.json
+++ b/templates/template-solid-ts/tsconfig.json
@@ -14,6 +14,7 @@
     "noEmit": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
+    "forceConsistentCasingInFileNames": true,
 
     /* Linting */
     "strict": true,

--- a/templates/template-vanilla-ts/tsconfig.json
+++ b/templates/template-vanilla-ts/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
 
     /* Linting */
     "strict": true,

--- a/templates/template-vue-ts/tsconfig.json
+++ b/templates/template-vue-ts/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
+    "forceConsistentCasingInFileNames": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->

1. Fixes https://github.com/tauri-apps/create-tauri-app/issues/935
2. Reroutes default build path to `builds` directory and adds gitignores for common build artefacts.
