### PR TITLE
Fixes blank window issue on Linux systems where Vite binds to IPv6 by…

### DIFF
--- a/templates/template-preact/vite.config.js.lte
+++ b/templates/template-preact/vite.config.js.lte
@@ -15,7 +15,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,{% if v2 %}
-    host: host || false,
+    host: host || "127.0.0.1",
     hmr: host
       ? {
           protocol: "ws",

--- a/templates/template-react/vite.config.js.lte
+++ b/templates/template-react/vite.config.js.lte
@@ -15,7 +15,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,{% if v2 %}
-    host: host || false,
+    host: host || "127.0.0.1",
     hmr: host
       ? {
           protocol: "ws",

--- a/templates/template-solid/vite.config.js.lte
+++ b/templates/template-solid/vite.config.js.lte
@@ -15,7 +15,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,{% if v2 %}
-    host: host || false,
+    host: host || "127.0.0.1",
     hmr: host
       ? {
           protocol: "ws",

--- a/templates/template-svelte-ts/vite.config.js.lte
+++ b/templates/template-svelte-ts/vite.config.js.lte
@@ -16,7 +16,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,{% if v2 %}
-    host: host || false,
+    host: host || "127.0.0.1",
     hmr: host
       ? {
           protocol: "ws",

--- a/templates/template-svelte/vite.config.js.lte
+++ b/templates/template-svelte/vite.config.js.lte
@@ -16,7 +16,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,{% if v2 %}
-    host: host || false,
+    host: host || "127.0.0.1",
     hmr: host
       ? {
           protocol: "ws",

--- a/templates/template-vue/vite.config.js.lte
+++ b/templates/template-vue/vite.config.js.lte
@@ -15,7 +15,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,{% if v2 %}
-    host: host || false,
+    host: host || "127.0.0.1",
     hmr: host
       ? {
           protocol: "ws",


### PR DESCRIPTION
 ## Problem
  When running `pnpm tauri dev` on Linux systems, the Tauri window displays blank/white. The browser dev tools show that the page loads correctly on `localhost:1420`, but the Tauri application window cannot connect to the dev server.

### Root Cause
  In all Vite-based templates, the host configuration is set to:
  ```javascript
  host: host || false
 ```

  When the TAURI_DEV_HOST environment variable is not set, this evaluates to false. On some systems (particularly Linux), Vite with host: false binds to IPv6 (::1) by default. However, Tauri's webview attempts to connect via IPv4 (127.0.0.1), causing a connection failure.

## Solution

  Change the default to explicitly use IPv4:
  host: host || "127.0.0.1"

  This ensures Vite always listens on IPv4 127.0.0.1:1420, allowing Tauri to connect properly regardless of the system's default binding behavior.