### PR TITLE
Update Dioxus template to 0.7

### DIFF
--- a/.changes/dioxus-update-v0.7.md
+++ b/.changes/dioxus-update-v0.7.md
@@ -1,5 +1,6 @@
 ---
 "create-tauri-app": "minor"
+"create-tauri-app-js": "minor"
 ---
 
 - Update `dioxus` to `0.7` with minor changes to the template.

--- a/.changes/dioxus-update-v0.7.md
+++ b/.changes/dioxus-update-v0.7.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": "minor"
+---
+
+- Update `dioxus` to `0.7` with minor changes to the template.
+- Disable interactive mode for `dx serve`. Fixes broken terminal when developing.

--- a/templates/template-dioxus/.manifest
+++ b/templates/template-dioxus/.manifest
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
 
-beforeDevCommand = dx serve --port 1420
+beforeDevCommand = dx serve --port 1420 --interactive false
 beforeBuildCommand = dx bundle --release
 devUrl = http://localhost:1420
 frontendDist = ../dist/public

--- a/templates/template-dioxus/Cargo.toml.lte
+++ b/templates/template-dioxus/Cargo.toml.lte
@@ -1,12 +1,12 @@
 [package]
 name = "{% package_name %}-ui"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-dioxus = { version = "0.6", features = ["web"] }
-dioxus-logger = "0.6"
+dioxus = { version = "0.7", features = ["web"] }
+dioxus-logger = "0.7"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"

--- a/templates/template-dioxus/src/app.rs.lte
+++ b/templates/template-dioxus/src/app.rs.lte
@@ -23,7 +23,9 @@ pub fn App() -> Element {
     let mut name = use_signal(|| String::new());
     let mut greet_msg = use_signal(|| String::new());
 
-    let greet = move |_: FormEvent| async move {
+    let greet = move |event: FormEvent| async move {
+        event.prevent_default();
+
         if name.read().is_empty() {
             return;
         }


### PR DESCRIPTION
- Followed [upgrade notes](https://dioxuslabs.com/learn/0.7/migration/to_07/) and updated the boilerplate. Verified that it works.
- ~~Unfortunately tauri does not seem to handle `dx serve --port 1420` properly in `beforeDevCommand` so I had to comment it out and run `dx serve` manually. Then tauri is able to start as normal and serve the web form.~~ Fixed `dx serve` integration by disabling interactive shell.
- Update Dioxus template to Rust 2024 edition

Fixes #943 