### PR TITLE
feat: add recommended by the Tauri documentation Cargo settings to a default Tauri template

### DIFF
--- a/templates/_base_/src-tauri/Cargo.toml.lte
+++ b/templates/_base_/src-tauri/Cargo.toml.lte
@@ -31,6 +31,7 @@ serde_json = "1"
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]{% endif %}
 
+# Read the optimization guideline for more details: https://tauri.app/concept/size/#cargo-configuration
 [profile.release]
 codegen-units = 1
 lto = true

--- a/templates/_base_/src-tauri/Cargo.toml.lte
+++ b/templates/_base_/src-tauri/Cargo.toml.lte
@@ -30,3 +30,13 @@ serde_json = "1"
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]{% endif %}
+
+[profile.dev]
+incremental = true
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = 3
+panic = "abort"
+strip = true

--- a/templates/_base_/src-tauri/Cargo.toml.lte
+++ b/templates/_base_/src-tauri/Cargo.toml.lte
@@ -31,9 +31,6 @@ serde_json = "1"
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]{% endif %}
 
-[profile.dev]
-incremental = true
-
 [profile.release]
 codegen-units = 1
 lto = true


### PR DESCRIPTION
Resolves https://github.com/tauri-apps/create-tauri-app/issues/945

I added [recommended](https://v2.tauri.app/concept/size/#cargo-configuration) Tauri settings to a default template.

The only change I've made it's a default `opt-level` - the documentation by default proposes to use `"s"` level, and switching to `3` otherwise. I don't know, do we still want to do it. Personally, I always try to prefer speed over binary by default (especially if we are not talking here about embedded stuff). Anyway, if Tauri devs are not thinking in the same way - I will change to the currently recommended `"s"` - no problem :) 