### PR TITLE
fix: remove unnecessary async from vite config templates

### DIFF
--- a/.changes/remove-unnecessary-async-from-vite-configs.md
+++ b/.changes/remove-unnecessary-async-from-vite-configs.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Remove unnecessary `async` keyword from `defineConfig` in Vite-based templates

--- a/templates/template-preact-ts/vite.config.ts.lte
+++ b/templates/template-preact-ts/vite.config.ts.lte
@@ -5,7 +5,7 @@ import preact from "@preact/preset-vite";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [preact()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-preact/vite.config.js.lte
+++ b/templates/template-preact/vite.config.js.lte
@@ -4,7 +4,7 @@ import preact from "@preact/preset-vite";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [preact()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-react-ts/vite.config.ts.lte
+++ b/templates/template-react-ts/vite.config.ts.lte
@@ -5,7 +5,7 @@ import react from "@vitejs/plugin-react";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [react()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-react/vite.config.js.lte
+++ b/templates/template-react/vite.config.js.lte
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [react()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-solid-ts/vite.config.ts.lte
+++ b/templates/template-solid-ts/vite.config.ts.lte
@@ -5,7 +5,7 @@ import solid from "vite-plugin-solid";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [solid()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-solid/vite.config.js.lte
+++ b/templates/template-solid/vite.config.js.lte
@@ -4,7 +4,7 @@ import solid from "vite-plugin-solid";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [solid()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-svelte-ts/vite.config.js.lte
+++ b/templates/template-svelte-ts/vite.config.js.lte
@@ -5,7 +5,7 @@ import { sveltekit } from "@sveltejs/kit/vite";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [sveltekit()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-svelte/vite.config.js.lte
+++ b/templates/template-svelte/vite.config.js.lte
@@ -5,7 +5,7 @@ import { sveltekit } from "@sveltejs/kit/vite";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [sveltekit()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-vanilla-ts/vite.config.ts.lte
+++ b/templates/template-vanilla-ts/vite.config.ts.lte
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //

--- a/templates/template-vue-ts/vite.config.ts.lte
+++ b/templates/template-vue-ts/vite.config.ts.lte
@@ -5,7 +5,7 @@ import vue from "@vitejs/plugin-vue";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [vue()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`

--- a/templates/template-vue/vite.config.js.lte
+++ b/templates/template-vue/vite.config.js.lte
@@ -4,7 +4,7 @@ import vue from "@vitejs/plugin-vue";{% if v2 %}
 const host = process.env.TAURI_DEV_HOST;{% endif %}
 
 // https://vite.dev/config/
-export default defineConfig(async () => ({
+export default defineConfig(() => ({
   plugins: [vue()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->

The `async` keyword in `defineConfig(async () => ({...}))` across all Vite-based templates is unnecessary since there are no `await` expressions inside the function body. This removes it to keep the code clean and accurate.
