### PR TITLE
fix: remove cmd-incompatible quotes from tauri-cli command

### DIFF
--- a/.changes/fix-tauri-cli-cmd-install-command.md
+++ b/.changes/fix-tauri-cli-cmd-install-command.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+Remove CMD-incompatible quotes from the printed `tauri-cli` install command.

--- a/.changes/fix-tauri-cli-cmd-install-command.md
+++ b/.changes/fix-tauri-cli-cmd-install-command.md
@@ -1,5 +1,6 @@
 ---
 "create-tauri-app": patch
+"create-tauri-app-js": patch
 ---
 
 Remove CMD-incompatible quotes from the printed `tauri-cli` install command.

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -170,8 +170,8 @@ pub fn print_missing_deps(
         Dep {
             name: "Tauri CLI",
             instruction: match tauri_version {
-                TauriVersion::V1 => format!("Run `{BLUE}{BOLD}cargo install tauri-cli --version '^1.0.0' --locked{RESET}`"),
-                TauriVersion::V2 => format!("Run `{BLUE}{BOLD}cargo install tauri-cli --version '^2.0.0' --locked{RESET}`"),
+                TauriVersion::V1 => format!("Run `{BLUE}{BOLD}cargo install tauri-cli --version ^1.0.0 --locked{RESET}`"),
+                TauriVersion::V2 => format!("Run `{BLUE}{BOLD}cargo install tauri-cli --version ^2.0.0 --locked{RESET}`"),
             },
             exists: &|| is_tauri_cli_installed(tauri_version),
             skip: pkg_manager.is_node() || !template.needs_tauri_cli(),


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->

fix: remove cmd-incompatible quotes from tauri-cli command

 Closes #849.

  Removes single quotes around the `tauri-cli` semver range in the printed `cargo install` command.

  On Windows CMD, single quotes are passed through as part of the argument, so the suggested command was invalid:

  ```cmd
  cargo install tauri-cli --version '^2.0.0' --locked
  ```
  The printed command is now:
  ```cmd
  cargo install tauri-cli --version ^2.0.0 --locked
  ```
  Added a patch change file for create-tauri-app.

  Tested with:

  cargo fmt --check
  cargo test
  cargo clippy