### PR TITLE
chore(deps): update vite to v8 typescript to v6

### DIFF
--- a/.changes/update-vite-ts-dependencies.md
+++ b/.changes/update-vite-ts-dependencies.md
@@ -1,0 +1,6 @@
+---
+"create-tauri-app": patch
+"create-tauri-app-js": patch
+---
+
+Updated vite to v8 and typescript to v6 for all templates

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -134,8 +134,10 @@ jobs:
 
       - name: download cli artifact
         uses: actions/download-artifact@v8
+        with:
+          name: create-tauri-app
 
-      - run: tar -xf create-tauri-app/create-tauri-app.tar
+      - run: tar -xf create-tauri-app.tar
 
       - name: bootstrap a ${{ matrix.settings.template }} project (${{ matrix.settings.flags }})
         run: ./target/release/cargo-create-tauri-app tauri-app -m ${{ matrix.settings.manager }} -t ${{ matrix.settings.template }} ${{ matrix.settings.flags }} -y

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -98,6 +98,7 @@ jobs:
           node-version: 22
 
       - uses: pnpm/action-setup@v6
+        if: matrix.settings.manager == 'pnpm'
         with:
           version: 10
 

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -29,9 +29,9 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changed-files
         with:
           list-files: shell
@@ -50,7 +50,7 @@ jobs:
     needs: [generate-matrix]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --release --package create-tauri-app
 
@@ -58,7 +58,7 @@ jobs:
         run: tar -rf create-tauri-app.tar target/release/cargo-create-tauri-app
 
       - name: upload cli artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: create-tauri-app
           path: create-tauri-app.tar
@@ -91,11 +91,11 @@ jobs:
           corepack enable
         if: matrix.settings.node
 
-      - name: Install Node.js@18
+      - name: Install Node.js@22
         if: matrix.settings.node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install .NET@8.0.x
         if: matrix.settings.manager == 'dotnet'
@@ -133,7 +133,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.1 libayatana-appindicator3-dev librsvg2-dev patchelf
 
       - name: download cli artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - run: tar -xf create-tauri-app/create-tauri-app.tar
 

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -97,6 +97,10 @@ jobs:
         with:
           node-version: 22
 
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
       - name: Install .NET@8.0.x
         if: matrix.settings.manager == 'dotnet'
         uses: actions/setup-dotnet@v4

--- a/templates/template-preact-ts/package.json.lte
+++ b/templates/template-preact-ts/package.json.lte
@@ -15,9 +15,9 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "@preact/preset-vite": "^2.9.3",
-    "typescript": "~5.6.2",
-    "vite": "^6.0.3",
+    "@preact/preset-vite": "^2.10.5",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.16",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-preact-ts/tsconfig.json
+++ b/templates/template-preact-ts/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/templates/template-preact/package.json.lte
+++ b/templates/template-preact/package.json.lte
@@ -15,8 +15,8 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "@preact/preset-vite": "^2.9.3",
-    "vite": "^6.0.3",
+    "@preact/preset-vite": "^2.10.5",
+    "vite": "^8.0.16",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-react-ts/package.json.lte
+++ b/templates/template-react-ts/package.json.lte
@@ -18,9 +18,9 @@
   "devDependencies": {
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "@vitejs/plugin-react": "^4.6.0",
-    "typescript": "~5.8.3",
-    "vite": "^7.0.4",
+    "@vitejs/plugin-react": "^6.0.2",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.16",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-react-ts/tsconfig.json
+++ b/templates/template-react-ts/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/templates/template-react/package.json.lte
+++ b/templates/template-react/package.json.lte
@@ -16,8 +16,8 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.6.0",
-    "vite": "^7.0.4",
+    "@vitejs/plugin-react": "^6.0.2",
+    "vite": "^8.0.16",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-solid-ts/package.json.lte
+++ b/templates/template-solid-ts/package.json.lte
@@ -17,9 +17,9 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "typescript": "~5.6.2",
-    "vite": "^6.0.3",
-    "vite-plugin-solid": "^2.11.0",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.16",
+    "vite-plugin-solid": "^2.11.12",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-solid-ts/tsconfig.json
+++ b/templates/template-solid-ts/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/templates/template-solid/package.json.lte
+++ b/templates/template-solid/package.json.lte
@@ -17,8 +17,8 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "vite": "^6.0.3",
-    "vite-plugin-solid": "^2.11.0",
+    "vite": "^8.0.16",
+    "vite-plugin-solid": "^2.11.12",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-svelte-ts/package.json.lte
+++ b/templates/template-svelte-ts/package.json.lte
@@ -17,13 +17,13 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.6",
-    "@sveltejs/kit": "^2.9.0",
-    "@sveltejs/vite-plugin-svelte": "^5.0.0",
-    "svelte": "^5.0.0",
-    "svelte-check": "^4.0.0",
-    "typescript": "~5.6.2",
-    "vite": "^6.0.3",
+    "@sveltejs/adapter-static": "^3.0.10",
+    "@sveltejs/kit": "^2.65.1",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "svelte": "^5.56.3",
+    "svelte-check": "^4.6.0",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.16",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-svelte/package.json.lte
+++ b/templates/template-svelte/package.json.lte
@@ -17,13 +17,13 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.6",
-    "@sveltejs/kit": "^2.9.0",
-    "@sveltejs/vite-plugin-svelte": "^5.0.0",
-    "svelte": "^5.0.0",
-    "svelte-check": "^4.0.0",
-    "typescript": "~5.6.2",
-    "vite": "^6.0.3",
+    "@sveltejs/adapter-static": "^3.0.10",
+    "@sveltejs/kit": "^2.65.1",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "svelte": "^5.56.3",
+    "svelte-check": "^4.6.0",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.16",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-vanilla-ts/package.json.lte
+++ b/templates/template-vanilla-ts/package.json.lte
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}",
-    "vite": "^6.0.3",
-    "typescript": "~5.6.2"
+		"vite": "^8.0.16",
+    "typescript": "~6.0.3"
   }
 }

--- a/templates/template-vanilla-ts/tsconfig.json
+++ b/templates/template-vanilla-ts/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/templates/template-vue-ts/package.json.lte
+++ b/templates/template-vue-ts/package.json.lte
@@ -15,10 +15,10 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.1",
-    "typescript": "~5.6.2",
-    "vite": "^6.0.3",
-    "vue-tsc": "^2.1.10",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.16",
+    "vue-tsc": "^3.3.5",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }

--- a/templates/template-vue-ts/tsconfig.json
+++ b/templates/template-vue-ts/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/templates/template-vue/package.json.lte
+++ b/templates/template-vue/package.json.lte
@@ -15,8 +15,8 @@
     "@tauri-apps/plugin-opener": "^2"{% endif %}
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.1",
-    "vite": "^6.0.3",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "vite": "^8.0.16",
     "@tauri-apps/cli": "{% if v2 %}^2{% else %}^1{% endif %}"
   }
 }


### PR DESCRIPTION
Updated vite to v8 and typescript to v6 for all templates

Fix https://github.com/tauri-apps/tauri/issues/15543

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(cli): fix cli invalid template name parsing
    - docs: update docstrings
    - feat: add `super-awesome-js-framework` template

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/create-tauri-app/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Open as a draft PR if your work is still in progress.
-->
