### PR TITLE
fix: remove universal napi builds

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -132,53 +132,11 @@ jobs:
           path: node/${{ env.APP_NAME }}.*.node
           if-no-files-found: error
 
-  build-universal-macOS:
-    name: Build universal macOS binary
-    needs:
-      - build
-    runs-on: macos-latest
-    defaults:
-      run:
-        working-directory: node
-    steps:
-      - uses: actions/checkout@v6
-      - run: |
-          npm i -g --force corepack
-          corepack enable
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Download macOS x64 artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: napi-x86_64-apple-darwin
-          path: node/artifacts
-
-      - name: Download macOS arm64 artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: napi-aarch64-apple-darwin
-          path: node/artifacts
-      - name: Combine binaries
-        run: pnpm universal
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: napi-universal-apple-darwin
-          path: node/${{ env.APP_NAME }}.darwin-universal.node
-          if-no-files-found: error
-
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs:
-      - build-universal-macOS
+      - build
     defaults:
       run:
         working-directory: node

--- a/node/package.json
+++ b/node/package.json
@@ -28,7 +28,6 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-pc-windows-msvc",
       "x86_64-apple-darwin",
-      "universal-apple-darwin",
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-linux-musl",
@@ -54,7 +53,6 @@
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm --gh-release-id $RELEASE_ID",
-    "universal": "napi universalize",
     "version": "napi version"
   }
 }


### PR DESCRIPTION
Reference: https://github.com/tauri-apps/create-tauri-app/issues/972#issuecomment-4741172121

Since we already publish arm64 and x86_64 ones, universal build isn't that useful, removing it