### PR TITLE
fix: sync SvelteKit config after install

### DIFF
--- a/.changes/fix-sveltekit-tsconfig-sync.md
+++ b/.changes/fix-sveltekit-tsconfig-sync.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+Run `svelte-kit sync` after installing generated Svelte templates so the referenced SvelteKit tsconfig exists before checks run.

--- a/.changes/fix-sveltekit-tsconfig-sync.md
+++ b/.changes/fix-sveltekit-tsconfig-sync.md
@@ -1,5 +1,6 @@
 ---
 "create-tauri-app": patch
+"create-tauri-app-js": patch
 ---
 
 Run `svelte-kit sync` after installing generated Svelte templates so the referenced SvelteKit tsconfig exists before checks run.

--- a/templates/template-svelte-ts/package.json.lte
+++ b/templates/template-svelte-ts/package.json.lte
@@ -7,6 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "tauri": "tauri"

--- a/templates/template-svelte/package.json.lte
+++ b/templates/template-svelte/package.json.lte
@@ -7,6 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
     "tauri": "tauri"


### PR DESCRIPTION
This makes the generated Svelte templates run `svelte-kit sync` during install, so the referenced `.svelte-kit/tsconfig.json` / `.svelte-kit/tsconfig.json` exists before the first editor check or type check runs.

It fixes the Svelte template regression reported in #876 without changing the generated app structure.