### PR TITLE
feat: update Blazor template to use Dotnet 10

### DIFF
--- a/.changes/template-blazor-net-10.md
+++ b/.changes/template-blazor-net-10.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": minor
+---
+
+Update the Blazor template to use .NET 10 with preloading and fingerprinting of client-side static assets.

--- a/templates/template-blazor/src/wwwroot/index.html
+++ b/templates/template-blazor/src/wwwroot/index.html
@@ -5,11 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri + Blazor</title>
     <base href="/" />
+    <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="css/app.css" />
+    <script type="importmap"></script>
   </head>
 
   <body>
     <div id="app"></div>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
   </body>
 </html>

--- a/templates/template-blazor/src/{% project_name_pascal_case %}.csproj
+++ b/templates/template-blazor/src/{% project_name_pascal_case %}.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/template-blazor/src/{% project_name_pascal_case %}.csproj
+++ b/templates/template-blazor/src/{% project_name_pascal_case %}.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.25" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates the Blazor template to use Dotnet 10 based on `dotnet new blazorwasm`.
The official Dotnet 10 template uses:
- [Preloaded Blazor framework static assets](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?view=aspnetcore-10.0#preloaded-blazor-framework-static-assets)
- [Fingerprint client-side static assets in standalone Blazor WebAssembly apps](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?view=aspnetcore-10.0#fingerprint-client-side-static-assets-in-standalone-blazor-webassembly-apps)

by default.