### PR TITLE
fix(ci): set renovate minimumReleaseAge to match pnpm gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": ["config:base", ":disableDependencyDashboard"],
   "packageRules": [
     {
+      "matchPackageNames": ["*"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "groupName": "templates dependencies",
       "matchFileNames": [
         "templates/**/*package.json",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":disableDependencyDashboard"],
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
   "packageRules": [
     {
       "matchPackageNames": ["*"],


### PR DESCRIPTION
some renovate is falling because of the missing minimumReleaseAge as pnpm defaults to 1 day
https://github.com/tauri-apps/create-tauri-app/actions/runs/32168513810/job/95813780885?pr=1006

'3 days' because that's how it is on other repos

https://github.com/tauri-apps/tauri-docs/blob/9464f4e6151685c704425494df39b3139d00eb40/renovate.json#L12-L16

https://github.com/tauri-apps/plugins-workspace/blob/db9c5998feff9384f9cbbefcbe0d45937c00a1fc/renovate.json#L17-L21

plus replacing base with recommended. Any specific reason to use base?